### PR TITLE
fixed path name for installing the csh scripts

### DIFF
--- a/gmtsar/CMakeLists.txt
+++ b/gmtsar/CMakeLists.txt
@@ -81,20 +81,6 @@ install (TARGETS gmtsar bperp calc_dop_orb conv esarp extend_orbit make_gaussian
 	RUNTIME DESTINATION bin
 	COMPONENT Runtime)
 
-install (PROGRAMS align.csh align_ALOS2_SCAN.csh align_ALOS_SLC.csh align_batch.csh align_batch_ALOS2_SCAN.csh
-	align_batch_ALOS_SLC.csh align_tops.csh align_tops_6par.csh align_tops_esd.csh baseline_table.csh
-	cleanup.csh create_frame_tops.csh dem2topo_ra.csh dem2topo_ra_ALOS2.csh detrend_before_unwrap.csh
-	filter.csh fitoffset.csh geocode.csh gmtsar.csh gmtsar_sharedir.csh grd2geotiff.csh grd2kml.csh intf.csh
-	intf_batch.csh intf_batch_ALOS2_SCAN.csh intf_tops.csh landmask.csh landmask_ALOS2.csh m2s.csh
-	make_a_offset.csh make_dem.csh make_los_ascii.csh make_profile.csh merge_batch.csh
-	merge_unwrap_geocode_tops.csh p2p_ALOS.csh p2p_ALOS2_SCAN_SLC.csh p2p_ALOS2_SLC.csh p2p_ALOS_SLC.csh
-	p2p_CSK.csh p2p_CSK_SLC.csh p2p_ENVI.csh p2p_ENVI_SLC.csh p2p_ERS.csh p2p_RS2_SLC.csh p2p_S1A_SLC.csh
-	p2p_S1A_TOPS.csh p2p_S1A_TOPS_Frame.csh p2p_SAT_SLC.csh p2p_TSX_SLC.csh pre_proc.csh pre_proc_batch.csh
-	pre_proc_batch_ALOS2_SCAN.csh pre_proc_batch_ALOS_SLC.csh pre_proc_init.csh preproc_batch_tops.csh
-	preproc_batch_tops_esd.csh proj_ll2ra.csh proj_ll2ra_ascii.csh proj_model.csh proj_ra2ll.csh
-	proj_ra2ll_ascii.csh sarp.csh slc2amp.csh snaphu.csh snaphu_interp.csh stack.csh stack_corr.csh 
-	update_PRM.csh select_pairs.csh
-	RUNTIME DESTINATION bin
-	COMPONENT Runtime)
+add_subdirectory (csh)
 
 # vim: textwidth=78 noexpandtab tabstop=2 softtabstop=2 shiftwidth=2

--- a/gmtsar/csh/CMakeLists.txt
+++ b/gmtsar/csh/CMakeLists.txt
@@ -1,3 +1,5 @@
+configure_file (gmtsar_sharedir.csh.in gmtsar_sharedir.csh)
+
 install (PROGRAMS align.csh align_ALOS2_SCAN.csh align_ALOS_SLC.csh align_batch.csh align_batch_ALOS2_SCAN.csh
 	align_batch_ALOS_SLC.csh align_tops.csh align_tops_6par.csh align_tops_esd.csh baseline_table.csh
 	cleanup.csh create_frame_tops.csh dem2topo_ra.csh dem2topo_ra_ALOS2.csh detrend_before_unwrap.csh

--- a/gmtsar/csh/CMakeLists.txt
+++ b/gmtsar/csh/CMakeLists.txt
@@ -1,0 +1,15 @@
+install (PROGRAMS align.csh align_ALOS2_SCAN.csh align_ALOS_SLC.csh align_batch.csh align_batch_ALOS2_SCAN.csh
+	align_batch_ALOS_SLC.csh align_tops.csh align_tops_6par.csh align_tops_esd.csh baseline_table.csh
+	cleanup.csh create_frame_tops.csh dem2topo_ra.csh dem2topo_ra_ALOS2.csh detrend_before_unwrap.csh
+	filter.csh fitoffset.csh geocode.csh gmtsar.csh gmtsar_sharedir.csh grd2geotiff.csh grd2kml.csh intf.csh
+	intf_batch.csh intf_batch_ALOS2_SCAN.csh intf_tops.csh landmask.csh landmask_ALOS2.csh m2s.csh
+	make_a_offset.csh make_dem.csh make_los_ascii.csh make_profile.csh merge_batch.csh
+	merge_unwrap_geocode_tops.csh p2p_ALOS.csh p2p_ALOS2_SCAN_SLC.csh p2p_ALOS2_SLC.csh p2p_ALOS_SLC.csh
+	p2p_CSK.csh p2p_CSK_SLC.csh p2p_ENVI.csh p2p_ENVI_SLC.csh p2p_ERS.csh p2p_RS2_SLC.csh p2p_S1A_SLC.csh
+	p2p_S1A_TOPS.csh p2p_S1A_TOPS_Frame.csh p2p_SAT_SLC.csh p2p_TSX_SLC.csh pre_proc.csh pre_proc_batch.csh
+	pre_proc_batch_ALOS2_SCAN.csh pre_proc_batch_ALOS_SLC.csh pre_proc_init.csh preproc_batch_tops.csh
+	preproc_batch_tops_esd.csh proj_ll2ra.csh proj_ll2ra_ascii.csh proj_model.csh proj_ra2ll.csh
+	proj_ra2ll_ascii.csh sarp.csh slc2amp.csh snaphu.csh snaphu_interp.csh stack.csh stack_corr.csh 
+	update_PRM.csh select_pairs.csh
+	RUNTIME DESTINATION bin
+	COMPONENT Runtime)

--- a/gmtsar/csh/CMakeLists.txt
+++ b/gmtsar/csh/CMakeLists.txt
@@ -6,9 +6,8 @@ install (PROGRAMS align.csh align_ALOS2_SCAN.csh align_ALOS_SLC.csh align_batch.
 	filter.csh fitoffset.csh geocode.csh gmtsar.csh gmtsar_sharedir.csh grd2geotiff.csh grd2kml.csh intf.csh
 	intf_batch.csh intf_batch_ALOS2_SCAN.csh intf_tops.csh landmask.csh landmask_ALOS2.csh m2s.csh
 	make_a_offset.csh make_dem.csh make_los_ascii.csh make_profile.csh merge_batch.csh
-	merge_unwrap_geocode_tops.csh p2p_ALOS.csh p2p_ALOS2_SCAN_SLC.csh p2p_ALOS2_SLC.csh p2p_ALOS_SLC.csh
-	p2p_CSK.csh p2p_CSK_SLC.csh p2p_ENVI.csh p2p_ENVI_SLC.csh p2p_ERS.csh p2p_RS2_SLC.csh p2p_S1A_SLC.csh
-	p2p_S1A_TOPS.csh p2p_S1A_TOPS_Frame.csh p2p_SAT_SLC.csh p2p_TSX_SLC.csh pre_proc.csh pre_proc_batch.csh
+    merge_unwrap_geocode_tops.csh p2p_ALOS2_SCAN_Frame.csh p2p_ALOS2_SCAN_SLC.csh
+	p2p_ENVI.csh p2p_ERS.csh p2p_S1_TOPS.csh p2p_S1_TOPS_Frame.csh pre_proc.csh pre_proc_batch.csh
 	pre_proc_batch_ALOS2_SCAN.csh pre_proc_batch_ALOS_SLC.csh pre_proc_init.csh preproc_batch_tops.csh
 	preproc_batch_tops_esd.csh proj_ll2ra.csh proj_ll2ra_ascii.csh proj_model.csh proj_ra2ll.csh
 	proj_ra2ll_ascii.csh sarp.csh slc2amp.csh snaphu.csh snaphu_interp.csh stack.csh stack_corr.csh 

--- a/gmtsar/csh/CMakeLists.txt
+++ b/gmtsar/csh/CMakeLists.txt
@@ -11,5 +11,5 @@ install (PROGRAMS align.csh align_ALOS2_SCAN.csh align_ALOS_SLC.csh align_batch.
 	preproc_batch_tops_esd.csh proj_ll2ra.csh proj_ll2ra_ascii.csh proj_model.csh proj_ra2ll.csh
 	proj_ra2ll_ascii.csh sarp.csh slc2amp.csh snaphu.csh snaphu_interp.csh stack.csh stack_corr.csh 
 	update_PRM.csh select_pairs.csh
-	RUNTIME DESTINATION bin
+	DESTINATION bin
 	COMPONENT Runtime)


### PR DESCRIPTION
Running `make install` fails when the csh scripts from `gmtsar/csh/` are to be installed, because the install command assumes these scripts to be in `gmtsar/` instead of `gmtsar/csh/`.

This PR fixes it by moving the install command for csh scripts into `gmtsar/csh/CMakeLists.txt` and including this new file in `gmtsar/CMakeLists.txt`.

With this issue fixed, `make install` still fails due to some missing files:
- `gmtsar/csh/gmtsar_sharedir.csh` however there is `gmtsar/csh/gmtsar_sharedir.csh.in`
- and the following files which (I guess) have been removed from this repository some time ago:
```
p2p_ALOS.csh
p2p_ALOS2_SCAN_SLC.csh
p2p_ALOS2_SLC.csh
p2p_ALOS_SLC.csh
p2p_CSK.csh
p2p_CSK_SLC.csh
p2p_ENVI.csh
p2p_ENVI_SLC.csh
p2p_ERS.csh
p2p_RS2_SLC.csh
p2p_S1A_SLC.csh
p2p_S1A_TOPS.csh
p2p_S1A_TOPS_Frame.csh
p2p_SAT_SLC.csh
p2p_TSX_SLC.csh
```