### PR TITLE
I believe this commit corrects an orbit interpolation error.

### DIFF
--- a/preproc/S1A_preproc/src_tops/make_s1a_tops.c
+++ b/preproc/S1A_preproc/src_tops/make_s1a_tops.c
@@ -592,15 +592,15 @@ double dramp_dmod(struct tree *xml_tree, int nb, fcomplex *cramp, int lpb, int w
 	search_tree(xml_tree, "/product/generalAnnotation/orbitList/orbit/velocity/x/", tmp_c, 1, 4, ii - 1);
 	vx = str2double(tmp_c);
 	search_tree(xml_tree, "/product/generalAnnotation/orbitList/orbit/velocity/x/", tmp_c, 1, 4, ii);
-	vx = (str2double(tmp_c) * (t2 - t_brst) + vx * (t_brst - t1)) / (t2 - t1);
+	vx = (str2double(tmp_c) * (t_brst - t1) + vx * (t2 - t_brst)) / (t2 - t1);
 	search_tree(xml_tree, "/product/generalAnnotation/orbitList/orbit/velocity/y/", tmp_c, 1, 4, ii - 1);
 	vy = str2double(tmp_c);
 	search_tree(xml_tree, "/product/generalAnnotation/orbitList/orbit/velocity/y/", tmp_c, 1, 4, ii);
-	vy = (str2double(tmp_c) * (t2 - t_brst) + vy * (t_brst - t1)) / (t2 - t1);
+	vy = (str2double(tmp_c) * (t_brst - t1) + vy * (t2 - t_brst)) / (t2 - t1);
 	search_tree(xml_tree, "/product/generalAnnotation/orbitList/orbit/velocity/z/", tmp_c, 1, 4, ii - 1);
 	vz = str2double(tmp_c);
 	search_tree(xml_tree, "/product/generalAnnotation/orbitList/orbit/velocity/z/", tmp_c, 1, 4, ii);
-	vz = (str2double(tmp_c) * (t2 - t_brst) + vz * (t_brst - t1)) / (t2 - t1);
+	vz = (str2double(tmp_c) * (t_brst - t1) + vz * (t2 - t_brst)) / (t2 - t1);
 
 	// malloc the memory
 	eta = (double *)malloc(lpb * sizeof(double));


### PR DESCRIPTION
It appears that the variables ii and t2 are used in an iteration to
find the index (ii) of the first orbit velocity entry that occurs at a
time (t2) after the burst time (t_brst). At the end of this iteration
t1 is the time of the last orbit velocity state prior to t_brst, and
the corresponding index is ii-1.

The code following this iteration interpolates vx, vy and vz for
t_brst. However, prior to the change in this commit, if one sets
t_brst to be t1, one would get vx, vy and vz associated with t2, and
vice versa.

I believe this is an error.

Thanks for your consideration.