### PR TITLE
changing malloc 80 to malloc 180 for larger S1 arrays

### DIFF
--- a/preproc/S1A_preproc/src_tops/make_s1a_tops.c
+++ b/preproc/S1A_preproc/src_tops/make_s1a_tops.c
@@ -393,7 +393,7 @@ int pop_burst(struct PRM *prm, tree *xml_tree, struct burst_bounds *bb, char *fi
 	kea = (int *)malloc((count + 1) * sizeof(int));
 	ker = (int *)malloc((count + 1) * sizeof(int));
 	kover = (int *)malloc((count + 1) * sizeof(int));
-	cflag_orig = (char *)malloc(sizeof(char) * 80 * (lpb + 1));
+	cflag_orig = (char *)malloc(sizeof(char) * 180 * (lpb + 1));
 	cflag = cflag_orig;
 
 	search_tree(xml_tree, "/product/imageAnnotation/imageInformation/productFirstLineUtcTime/", tmp_c, 2, 0, 1);


### PR DESCRIPTION
For preprocessing valid S1A tiff files (large, but less than 4Gb), I ran into an issue with make_s1a_tops. The error code was "malloc(): corrupted top size. Aborted (core dumped)."  preproc failed. 

Based on a post in the forums, I fixed it by increasing the size of a make_s1a_tops variable in malloc() from 80 to 180, and then re-making GMTSAR.  The issue was resolved.  

Thanks to Yunfeng Tian for solving this issue two years ago.  Thought it would be good to fix it at the source.  

Forum post: http://gmt.soest.hawaii.edu/boards/6/topics/7057
System information: I am on Ubuntu 20.04, GMTSAR6.0, cloned only a few days ago
