### PR TITLE
Edited the fetchOrbit.py due to changes again on the orbit download link and remove waterbody from the phasefilt.grd.

### DIFF
--- a/gmtsar/csh/fetchOrbit.py
+++ b/gmtsar/csh/fetchOrbit.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 import numpy as np
-import re
 import requests
+import re
 import os
 import argparse
 import datetime
@@ -66,12 +66,13 @@ class MyHTMLParser(HTMLParser):
     def handle_starttag(self, tag, attrs):
         for name, val in attrs:
             if name == 'href':
-                if val.startswith("https://scihub.copernicus.eu/gnss/odata") and val.endswith("Products('Quicklook')/$value"):
-                    pass
-                elif val.startswith("https://scihub.copernicus.eu/gnss/odata") and val.endswith("/"):
+                if val.startswith("https://scihub.copernicus.eu/gnss/odata") and val.endswith(")/"):
                     pass
                 else:
-                    self._url = val.strip()
+                    downloadLink = val.strip()
+                    downloadLink = downloadLink.split("/Products('Quicklook')")
+                    downloadLink = downloadLink[0] + downloadLink[-1]
+                    self._url = downloadLink
                 
     def handle_data(self, data):
         if data.startswith("S1") and data.endswith(".EOF"):
@@ -151,7 +152,7 @@ if __name__ == '__main__':
                 tbef, taft, mission = fileToRange(os.path.basename(result))
                 if (tbef <= fileTSStart) and (taft >= fileTS):
                     matchFileName = result
-                    match = os.path.join(resulturl)
+                    match = os.path.join(server[0:-5],resulturl[36:])
 
             if match is not None:
                 success = True

--- a/gmtsar/csh/snaphu.csh
+++ b/gmtsar/csh/snaphu.csh
@@ -101,6 +101,8 @@ gmt grdmath tmp.grd mask2_patch.grd MUL = tmp.grd
 if (-e landmask_ra.grd) then
   gmt grdmath unwrap.grd landmask_ra_patch.grd MUL = tmp.grd $V
   mv tmp.grd unwrap.grd
+  gmt grdmath phasefilt.grd landmask_ra_patch.grd MUL = tmp2.grd $V
+  mv tmp2.grd phasefilt.grd
 endif
 #
 # user defined mask

--- a/gmtsar/csh/snaphu_interp.csh
+++ b/gmtsar/csh/snaphu_interp.csh
@@ -120,6 +120,8 @@ endif
 if (-e mask_def.grd) then
   gmt grdmath unwrap.grd mask_def_patch.grd MUL = tmp.grd $V
   mv tmp.grd unwrap.grd
+  gmt grdmath phasefilt.grd landmask_ra_patch.grd MUL = tmp2.grd -V
+  mv tmp2.grd phasefilt.grd
 endif
 #
 #  plot the unwrapped phase

--- a/gmtsar/csh/snaphu_interp.csh
+++ b/gmtsar/csh/snaphu_interp.csh
@@ -111,7 +111,7 @@ gmt grdmath tmp.grd mask2_patch.grd MUL = tmp.grd
 if (-e landmask_ra.grd) then
   gmt grdmath unwrap.grd landmask_ra_patch.grd MUL = tmp.grd $V
   mv tmp.grd unwrap.grd
-  gmt grdmath phasefilt.grd landmask_ra_patch.grd MUL = tmp2.grd -V
+  gmt grdmath phasefilt.grd landmask_ra_patch.grd MUL = tmp2.grd $V
   mv tmp2.grd phasefilt.grd
 endif
 #

--- a/gmtsar/csh/snaphu_interp.csh
+++ b/gmtsar/csh/snaphu_interp.csh
@@ -120,7 +120,7 @@ endif
 if (-e mask_def.grd) then
   gmt grdmath unwrap.grd mask_def_patch.grd MUL = tmp.grd $V
   mv tmp.grd unwrap.grd
-  gmt grdmath phasefilt.grd landmask_ra_patch.grd MUL = tmp2.grd -V
+  gmt grdmath phasefilt.grd landmask_ra_patch.grd MUL = tmp2.grd $V
   mv tmp2.grd phasefilt.grd
 endif
 #

--- a/gmtsar/csh/snaphu_interp.csh
+++ b/gmtsar/csh/snaphu_interp.csh
@@ -111,6 +111,8 @@ gmt grdmath tmp.grd mask2_patch.grd MUL = tmp.grd
 if (-e landmask_ra.grd) then
   gmt grdmath unwrap.grd landmask_ra_patch.grd MUL = tmp.grd $V
   mv tmp.grd unwrap.grd
+  gmt grdmath phasefilt.grd landmask_ra_patch.grd MUL = tmp2.grd -V
+  mv tmp2.grd phasefilt.grd
 endif
 #
 # user defined mask

--- a/gmtsar/csh/snaphu_interp.csh
+++ b/gmtsar/csh/snaphu_interp.csh
@@ -120,8 +120,6 @@ endif
 if (-e mask_def.grd) then
   gmt grdmath unwrap.grd mask_def_patch.grd MUL = tmp.grd $V
   mv tmp.grd unwrap.grd
-  gmt grdmath phasefilt.grd landmask_ra_patch.grd MUL = tmp2.grd $V
-  mv tmp2.grd phasefilt.grd
 endif
 #
 #  plot the unwrapped phase


### PR DESCRIPTION
I've made some changes on the fetchOrbit.py since ESA Copernicus has changed again the download link on the XML of the scihub GNSS Copernicus website. I've also implemented these changes in ISCE2 (https://github.com/isce-framework/isce2/pull/273).

I've also proposed some changes on snaphu.csh and snaphu_interp.csh to remove the waterbody from the phasefilt.grd.