### PR TITLE
Set some processing script to accept mask_water parameter

### DIFF
--- a/gmtsar/csh/intf_batch.csh
+++ b/gmtsar/csh/intf_batch.csh
@@ -100,6 +100,7 @@ unset noclobber
   set switch_land = `grep switch_land $3 | awk '{print $3}'`
   set defomax = `grep defomax $3 | awk '{print $3}'`
   set near_interp = `grep near_interp $3 | awk '{print $3}'`
+  set mask_water = `grep mask_water $conf | awk '{print $3}'`
 #
 ##################################
 # 1 - start from make topo_ra  #
@@ -232,7 +233,7 @@ if ($stage <= 2) then
       set region_cut = `gmt grdinfo phase.grd -I- | cut -c3-20`
     endif
     if ($threshold_snaphu != 0 ) then
-      if ($switch_land == 1) then
+      if if ($mask_water == 1 || $switch_land == 1) then
         cd ../../topo
         if (! -f landmask_ra.grd) then
           landmask.csh $region_cut

--- a/gmtsar/csh/intf_batch.csh
+++ b/gmtsar/csh/intf_batch.csh
@@ -100,7 +100,7 @@ unset noclobber
   set switch_land = `grep switch_land $3 | awk '{print $3}'`
   set defomax = `grep defomax $3 | awk '{print $3}'`
   set near_interp = `grep near_interp $3 | awk '{print $3}'`
-  set mask_water = `grep mask_water $conf | awk '{print $3}'`
+  set mask_water = `grep mask_water $3 | awk '{print $3}'`
 #
 ##################################
 # 1 - start from make topo_ra  #

--- a/gmtsar/csh/intf_batch.csh
+++ b/gmtsar/csh/intf_batch.csh
@@ -233,7 +233,7 @@ if ($stage <= 2) then
       set region_cut = `gmt grdinfo phase.grd -I- | cut -c3-20`
     endif
     if ($threshold_snaphu != 0 ) then
-      if if ($mask_water == 1 || $switch_land == 1) then
+      if ($mask_water == 1 || $switch_land == 1) then
         cd ../../topo
         if (! -f landmask_ra.grd) then
           landmask.csh $region_cut

--- a/gmtsar/csh/intf_batch_ALOS2_SCAN.csh
+++ b/gmtsar/csh/intf_batch_ALOS2_SCAN.csh
@@ -85,7 +85,7 @@ unset noclobber
   set range_dec = `grep range_dec $3 | awk '{print $3}'`
   set azimuth_dec = `grep azimuth_dec $3 | awk '{print $3}'`
   set near_interp = `grep near_interp $3 | awk '{print $3}'`
-  set mask_water = `grep mask_water $conf | awk '{print $3}'`
+  set mask_water = `grep mask_water $3 | awk '{print $3}'`
 #
 # loop over 5 subswath
 #

--- a/gmtsar/csh/intf_batch_ALOS2_SCAN.csh
+++ b/gmtsar/csh/intf_batch_ALOS2_SCAN.csh
@@ -85,6 +85,7 @@ unset noclobber
   set range_dec = `grep range_dec $3 | awk '{print $3}'`
   set azimuth_dec = `grep azimuth_dec $3 | awk '{print $3}'`
   set near_interp = `grep near_interp $3 | awk '{print $3}'`
+  set mask_water = `grep mask_water $conf | awk '{print $3}'`
 #
 # loop over 5 subswath
 #
@@ -244,7 +245,7 @@ if ($stage <= 2) then
 
     if ($threshold_snaphu != 0 ) then
 
-      if ($switch_land == 1) then
+      if ($mask_water == 1 || $switch_land == 1) then
         cd ../../topo
         if (! -f landmask_ra.grd) then
           landmask_ALOS2.csh $region_cut

--- a/gmtsar/csh/intf_tops.csh
+++ b/gmtsar/csh/intf_tops.csh
@@ -66,6 +66,7 @@
   set range_dec = `grep range_dec $2 | awk '{print $3}'`
   set azimuth_dec = `grep azimuth_dec $2 | awk '{print $3}'`
   set near_interp = `grep near_interp $2 | awk '{print $3}'`
+  set mask_water = `grep mask_water $conf | awk '{print $3}'`
 
 ##################################
 # 1 - start from make topo_ra  #
@@ -191,7 +192,7 @@ if ($stage <= 2) then
 #
     
     if ($threshold_snaphu != 0 ) then
-      if ($switch_land == 1) then
+      if ($mask_water == 1 || $switch_land == 1) then
         #if ($region_cut == "") then
         set mask_region = `gmt grdinfo phase.grd -I- | cut -c3-20`
         #endif

--- a/gmtsar/csh/intf_tops.csh
+++ b/gmtsar/csh/intf_tops.csh
@@ -66,7 +66,7 @@
   set range_dec = `grep range_dec $2 | awk '{print $3}'`
   set azimuth_dec = `grep azimuth_dec $2 | awk '{print $3}'`
   set near_interp = `grep near_interp $2 | awk '{print $3}'`
-  set mask_water = `grep mask_water $conf | awk '{print $3}'`
+  set mask_water = `grep mask_water $2 | awk '{print $3}'`
 
 ##################################
 # 1 - start from make topo_ra  #

--- a/gmtsar/csh/merge_unwrap_geocode_tops.csh
+++ b/gmtsar/csh/merge_unwrap_geocode_tops.csh
@@ -109,13 +109,14 @@
   set switch_land = `grep switch_land $2 | awk '{print $3}'`
   set defomax = `grep defomax $2 | awk '{print $3}'`
   set near_interp = `grep near_interp $2 | awk '{print $3}'`
+  set mask_water = `grep mask_water $conf | awk '{print $3}'`
 
   # Unwrapping
   if ($region_cut == "") then
     set region_cut = `gmt grdinfo phasefilt.grd -I- | cut -c3-20`
   endif
   if ($threshold_snaphu != 0 ) then
-    if ($switch_land == 1) then
+    if ($mask_water == 1 || $switch_land == 1) then
       if (! -f landmask_ra.grd) then
         landmask.csh $region_cut
       endif

--- a/gmtsar/csh/merge_unwrap_geocode_tops.csh
+++ b/gmtsar/csh/merge_unwrap_geocode_tops.csh
@@ -109,7 +109,7 @@
   set switch_land = `grep switch_land $2 | awk '{print $3}'`
   set defomax = `grep defomax $2 | awk '{print $3}'`
   set near_interp = `grep near_interp $2 | awk '{print $3}'`
-  set mask_water = `grep mask_water $conf | awk '{print $3}'`
+  set mask_water = `grep mask_water $2 | awk '{print $3}'`
 
   # Unwrapping
   if ($region_cut == "") then

--- a/gmtsar/csh/p2p_ALOS2_SCAN_SLC.csh
+++ b/gmtsar/csh/p2p_ALOS2_SCAN_SLC.csh
@@ -87,7 +87,7 @@ unset noclobber
   set switch_land = `grep switch_land $3 | awk '{print $3}'`
   set defomax = `grep defomax $3 | awk '{print $3}'`
   set near_interp = `grep near_interp $3 | awk '{print $3}'`
-  set mask_water = `grep mask_water $conf | awk '{print $3}'`
+  set mask_water = `grep mask_water $3 | awk '{print $3}'`
 #
 # read file names of raw data
 #

--- a/gmtsar/csh/p2p_ALOS2_SCAN_SLC.csh
+++ b/gmtsar/csh/p2p_ALOS2_SCAN_SLC.csh
@@ -87,6 +87,7 @@ unset noclobber
   set switch_land = `grep switch_land $3 | awk '{print $3}'`
   set defomax = `grep defomax $3 | awk '{print $3}'`
   set near_interp = `grep near_interp $3 | awk '{print $3}'`
+  set mask_water = `grep mask_water $conf | awk '{print $3}'`
 #
 # read file names of raw data
 #
@@ -348,7 +349,7 @@ unset noclobber
 #
 # landmask
 #
-      if ($switch_land == 1) then
+      if ($mask_water == 1 || $switch_land == 1) then
         cd ../../topo
         if (! -f landmask_ra.grd) then
           landmask.csh $region_cut

--- a/gmtsar/csh/p2p_ENVI.csh
+++ b/gmtsar/csh/p2p_ENVI.csh
@@ -75,7 +75,7 @@ if ($#argv < 3) then
   set switch_land = `grep switch_land $3 | awk '{print $3}'`
   set defomax = `grep defomax $3 | awk '{print $3}'`
   set near_interp = `grep near_interp $3 | awk '{print $3}'`
-  set mask_water = `grep mask_water $conf | awk '{print $3}'`
+  set mask_water = `grep mask_water $3 | awk '{print $3}'`
 
 #
 # read file names of raw data

--- a/gmtsar/csh/p2p_ENVI.csh
+++ b/gmtsar/csh/p2p_ENVI.csh
@@ -75,6 +75,7 @@ if ($#argv < 3) then
   set switch_land = `grep switch_land $3 | awk '{print $3}'`
   set defomax = `grep defomax $3 | awk '{print $3}'`
   set near_interp = `grep near_interp $3 | awk '{print $3}'`
+  set mask_water = `grep mask_water $conf | awk '{print $3}'`
 
 #
 # read file names of raw data
@@ -286,7 +287,7 @@ if ($#argv < 3) then
 #
 # landmask
 #
-      if ($switch_land == 1) then
+      if ($mask_water == 1 || $switch_land == 1) then
         cd ../../topo
         if (! -f landmask_ra.grd) then
           landmask.csh $region_cut

--- a/gmtsar/csh/p2p_ERS.csh
+++ b/gmtsar/csh/p2p_ERS.csh
@@ -76,7 +76,7 @@ if ($#argv < 3) then
   set switch_land = `grep switch_land $3 | awk '{print $3}'`
   set defomax = `grep defomax $3 | awk '{print $3}'`
   set near_interp = `grep near_interp $3 | awk '{print $3}'`
-  set mask_water = `grep mask_water $conf | awk '{print $3}'`
+  set mask_water = `grep mask_water $3 | awk '{print $3}'`
 
 #
 # read file names of raw data

--- a/gmtsar/csh/p2p_ERS.csh
+++ b/gmtsar/csh/p2p_ERS.csh
@@ -76,6 +76,7 @@ if ($#argv < 3) then
   set switch_land = `grep switch_land $3 | awk '{print $3}'`
   set defomax = `grep defomax $3 | awk '{print $3}'`
   set near_interp = `grep near_interp $3 | awk '{print $3}'`
+  set mask_water = `grep mask_water $conf | awk '{print $3}'`
 
 #
 # read file names of raw data
@@ -288,7 +289,7 @@ if ($#argv < 3) then
 #
 # landmask
 #
-      if ($switch_land == 1) then
+      if ($mask_water == 1 || $switch_land == 1) then
         cd ../../topo
         if (! -f landmask_ra.grd) then
           landmask.csh $region_cut

--- a/gmtsar/csh/p2p_S1_TOPS.csh
+++ b/gmtsar/csh/p2p_S1_TOPS.csh
@@ -78,6 +78,7 @@ unset noclobber
   set range_dec = `grep range_dec $3 | awk '{print $3}'`
   set azimuth_dec = `grep azimuth_dec $3 | awk '{print $3}'`
   set near_interp = `grep near_interp $3 | awk '{print $3}'`
+  set mask_water = `grep mask_water $conf | awk '{print $3}'`
 #
 # read file names of raw data
 #
@@ -304,7 +305,7 @@ unset noclobber
 #
 # landmask
 #
-      if ($switch_land == 1) then
+      if ($mask_water == 1 || $switch_land == 1) then
         cd ../../topo
         if (! -f landmask_ra.grd) then
           landmask.csh $region_cut

--- a/gmtsar/csh/p2p_S1_TOPS.csh
+++ b/gmtsar/csh/p2p_S1_TOPS.csh
@@ -78,7 +78,7 @@ unset noclobber
   set range_dec = `grep range_dec $3 | awk '{print $3}'`
   set azimuth_dec = `grep azimuth_dec $3 | awk '{print $3}'`
   set near_interp = `grep near_interp $3 | awk '{print $3}'`
-  set mask_water = `grep mask_water $conf | awk '{print $3}'`
+  set mask_water = `grep mask_water $3 | awk '{print $3}'`
 #
 # read file names of raw data
 #


### PR DESCRIPTION
As I'm generating InSAR maps, I've found out that some of the processing scripts don't incorporate the mask_water parameter which is generated by pop_config.csh. I've edited those scripts so they can accept either accept switch_land or mask_water parameter during processing.