### PR TITLE
Include python scripts during make install

### DIFF
--- a/gmtsar/Makefile
+++ b/gmtsar/Makefile
@@ -48,7 +48,7 @@ all:		$(PROGS)
 install:	all
 		$(INSTALL) -d $(bindir)
 		$(INSTALL) $(PROGS) $(bindir)
-		ls csh/*.csh csh/*.sh > /tmp/t.lis
+		ls csh/*.csh csh/*.sh csh/*.py > /tmp/t.lis
 		$(INSTALL) `cat /tmp/t.lis` $(bindir)
 		rm -f /tmp/t.lis
 


### PR DESCRIPTION
I've edited this Makefile to include python scripts on the bin folder during execution of make install