### PR TITLE
Plot stack.csh script results to PDF

### DIFF
--- a/gmtsar/csh/unwrap_intf_masked.sh
+++ b/gmtsar/csh/unwrap_intf_masked.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# intflist contains a list of all date1_date2 directories.
+set -e
+
+cd "$1"
+
+if [ -z "${GMTSAR_THRESHOLD_SNAPHU_MASKED}" ]
+then
+    thr=0.001
+else
+    thr="${GMTSAR_THRESHOLD_SNAPHU_MASKED}"
+fi
+if [ -z "${GMTSAR_DEFOMAX}" ]
+then
+    jumps=0
+else
+    jumps="${GMTSAR_DEFOMAX}"
+fi
+
+ln -s ../mask_def.grd .
+snaphu_interp.csh "$thr" "$jumps"
+cd ..

--- a/gmtsar/csh/unwrap_intf_masked.sh
+++ b/gmtsar/csh/unwrap_intf_masked.sh
@@ -17,6 +17,12 @@ else
     jumps="${GMTSAR_DEFOMAX}"
 fi
 
-ln -f -s ../mask_def.grd .
+# make symlink to file in directory above if it is not exists
+# for linked directories we need to copy the mask to here before
+if [ ! -f mask_def.grd ]
+then
+    ln -f -s ../mask_def.grd .
+fi
+echo snaphu_interp.csh "$thr" "$jumps"
 snaphu_interp.csh "$thr" "$jumps"
 cd ..

--- a/gmtsar/csh/unwrap_intf_masked.sh
+++ b/gmtsar/csh/unwrap_intf_masked.sh
@@ -17,6 +17,6 @@ else
     jumps="${GMTSAR_DEFOMAX}"
 fi
 
-ln -s ../mask_def.grd .
+ln -f -s ../mask_def.grd .
 snaphu_interp.csh "$thr" "$jumps"
 cd ..

--- a/gmtsar/csh/unwrap_intf_unmasked.sh
+++ b/gmtsar/csh/unwrap_intf_unmasked.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# intflist contains a list of all date1_date2 directories.
+set -e
+
+cd "$1"
+if [ -z "${GMTSAR_THRESHOLD_SNAPHU_UNMASKED}" ]
+then
+    thr=0.10
+else
+    thr="${GMTSAR_THRESHOLD_SNAPHU_UNMASKED}"
+fi
+if [ -z "${GMTSAR_DEFOMAX}" ]
+then
+    jumps=0
+else
+    jumps="${GMTSAR_DEFOMAX}"
+fi
+snaphu_interp.csh "$thr" "$jumps"
+cd ..

--- a/gmtsar/csh/unwrap_parallel.csh
+++ b/gmtsar/csh/unwrap_parallel.csh
@@ -4,16 +4,16 @@
 #
 # Unwrap interferograms parallelly using GNU parallel
 #
-# IMPORTANT: put a script called unwrap_intf.csh in the current folder
+# IMPORTANT: put a script called unwrap_intf.csh in the current folder or in binary PATH
 # e.g. 
 #   cd $1
 #   snaphu[_interp].csh 0.1 0 
 #   cd ..
 #
 
-if ($#argv != 2) then
+if ($#argv != 3) then
   echo ""
-  echo "Usage: unwrap_parallel.csh intflist Ncores"
+  echo "Usage: unwrap_parallel.csh unwrap_script intflist Ncores"
   echo ""
   echo "    Run unwrapping jobs parallelly. Need to install GNU parallel first."
   echo "    Note, run this in the intf_all folder where all the interferograms are stored. "
@@ -21,11 +21,13 @@ if ($#argv != 2) then
   exit
 endif
 
-set ncores = $2
+set unwrapscript = $1
+set intflist = $2
+set ncores = $3
 set d1 = `date`
 
-foreach line (`awk '{print $0}' $1`)
-  echo "unwrap_intf.csh $line > log_$line.txt" >> unwrap.cmd
+foreach line (`awk '{print $0}' $intflist`)
+  echo "$unwrapscript $line > log_$line.txt" >> unwrap.cmd
 end
 
 parallel --jobs $ncores < unwrap.cmd


### PR DESCRIPTION
That's helpful to have ability to easy check the stacking results (i.e. send the plots to Telegram messenger from cloud processing host). See some outputs below:
[corr_stack.pdf](https://github.com/gmtsar/gmtsar/files/7016438/corr_stack.pdf)
[std.pdf](https://github.com/gmtsar/gmtsar/files/7016439/std.pdf)

Changes to unwrap_parallel.csh more complex because existing arguments of the script reordered. That's possible to save the order and add 3rd argument as the rollback script name. It should be more easy than use the code above for every GMTSAR launch on new (cloud) host:
```
# https://topex.ucsd.edu/gmtsar/tar/sentinel_time_series_3.pdf
# see page 19
cat << EOF > /usr/local/GMTSAR/bin/unwrap_intf_unmasked.csh
#!/bin/sh
# intflist contains a list of all date1_date2 directories.
set -e

cd "\$1"
if [ -z "\${GMTSAR_SNAPHU_UNMASKED_THRESHOLD}" ]
then
    thr=0.10
else
    thr="\${GMTSAR_SNAPHU_UNMASKED_THRESHOLD}"
fi
snaphu_interp.csh "\$thr" 0
cd ..
EOF
chmod a+x /usr/local/GMTSAR/bin/unwrap_intf_unmasked.sh

# https://topex.ucsd.edu/gmtsar/tar/sentinel_time_series_3.pdf
# see page 23
cat << EOF > /usr/local/GMTSAR/bin/unwrap_intf_masked.csh
#!/bin/sh
# intflist contains a list of all date1_date2 directories.
set -e

cd "\$1"

if [ -z "\${GMTSAR_SNAPHU_MASKED_THRESHOLD}" ]
then
    thr=0.001
else
    thr="\${GMTSAR_SNAPHU_MASKED_THRESHOLD}"
fi

ln -s ../mask_def.grd .
snaphu_interp.csh "\$thr" 0
cd ..
EOF
chmod a+x /usr/local/GMTSAR/bin/unwrap_intf_masked.sh
```