### PR TITLE
det_stitch pixel offset for two subswath

### DIFF
--- a/gmtsar/csh/merge_unwrap_geocode_tops.csh
+++ b/gmtsar/csh/merge_unwrap_geocode_tops.csh
@@ -130,7 +130,8 @@
     echo "Stitching postitions set to $n1 $n2"
   endif
   
-  if ($n1 > 5 && $n2 > 5) then
+  # for two subswath (n1 >5, n2 =0), for three subswath (n1>5, n2>5) subswath merge with pixel offset computed from det_stich flag
+  if ($n1 > 5) then
     merge_swath tmp_phaselist phasefilt.grd $stem $n1 $n2> merge_log
     merge_swath tmp_corrlist corr.grd $n1 $n2 > merge_log_corr
     merge_swath tmp_masklist mask.grd $n1 $n2 > merge_log_mask


### PR DESCRIPTION
pixel offset computed by det_stitch for two subswath merge scenario is not being applied in the script. For two subswath n2 is always zero, so the script skips sending both n1 and n2 to the c file.