### PR TITLE
Bug fixes for alignment with ALOS SLCs. 

### DIFF
--- a/gmtsar/csh/align_ALOS_SLC.csh
+++ b/gmtsar/csh/align_ALOS_SLC.csh
@@ -60,7 +60,7 @@ unset noclobber
 #   use the PRF of the supermaster in the surrogate master
 #
     set PRF = `grep PRF $3.PRM | awk '{print $3}'`
-    update_PRM $1.PRM PRM $PRF
+    update_PRM $1.PRM PRF $PRF
   else
     set RSHIFT = `SAT_baseline $1.PRM $2.PRM | grep rshift | awk '{print $3}'`
     set ASHIFT = `SAT_baseline $1.PRM $2.PRM | grep ashift | awk '{print $3}'`

--- a/gmtsar/csh/align_batch_ALOS_SLC.csh
+++ b/gmtsar/csh/align_batch_ALOS_SLC.csh
@@ -58,9 +58,9 @@
       update_PRM IMG-HH-$supermasterstem.PRM SLC_file IMG-HH-$supermasterstem.SLC
       ln -s ../raw/IMG-HH-$masterstem.SLC . 
       ln -s ../raw/IMG-HH-$alignedstem.SLC . 
-      ln -s ../raw/LED-$masterstem . 
-      ln -s ../raw/LED-$alignedstem .
-      ln -s ../raw/LED-$supermasterstem .
+      ln -s ../raw/IMG-HH-$masterstem.LED . 
+      ln -s ../raw/IMG-HH-$alignedstem.LED .
+      ln -s ../raw/IMG-HH-$supermasterstem.LED .
       align_ALOS_SLC.csh $master $aligned $supermaster
       cd ..
       echo "Align $aligned to $master via $supermaster - END"


### PR DESCRIPTION
2 changes: fix typo PRM to PRF in align_ALOS_SLC.csh, and update name of LED files in align_batch_ALOS_SLC.csh.