### PR TITLE
Fix printf issue and allow to redefine default filenames

### DIFF
--- a/gmtsar/SAT_baseline.c
+++ b/gmtsar/SAT_baseline.c
@@ -481,12 +481,12 @@ void baseline_parse_command_line(char **argv, int *nfiles, int *input_flag) {
 
 	if (strncmp(argv[1], "-input", 6) != 0) {
 
-		printf(stderr, "using command line\n");
+		fprintf(stderr, "using command line\n");
 		*nfiles = 2;
 	}
 	else {
 
-		printf(stderr, "using input file \n");
+		fprintf(stderr, "using input file \n");
 		*input_flag = 1;
 
 		if ((inputfile = fopen(argv[2], "r")) == NULL)

--- a/gmtsar/lib_functions.h
+++ b/gmtsar/lib_functions.h
@@ -65,7 +65,7 @@ void read_complex_short(FILE *f, int *d, int iy, int jx, int npx, int npy, int n
 void read_real_float(FILE *f, int *d, int iy, int jx, int npx, int npy, int nx);
 void read_data(struct xcorr xc);
 void read_complex_short2float(FILE *f, float *d, int iy, int jx, int npx, int npy, int nx);
-void read_optional_args(void *API, int argc, char **argv, struct PRM *tp, int *topoflag, struct PRM *mp, int *modelflag);
+void read_optional_args(void *API, int argc, char **argv, struct PRM *tp, int *topoflag, struct PRM *mp, int *modelflag, char *imag_filename, char *real_filename);
 void read_xcorr_data(struct xcorr *xc, int iloc);
 void rmpatch(fcomplex **data, int nrows, double delr, double fd, double fdd, double fddd);
 void rng_cmp(void *API, int ranfft, fcomplex *data, fcomplex *ref);

--- a/gmtsar/make_gaussian_filter.c
+++ b/gmtsar/make_gaussian_filter.c
@@ -23,7 +23,7 @@ int strasign(char *, char *, int, int);
 int strlocate(char *, int, int);
 
 char *USAGE = "\n\nUsage: make_gaussian_filter name_of_PRM_file RNG_DEC "
-              "AZI_DEC WAVELENGTH(m)\n"
+              "AZI_DEC WAVELENGTH(m) [output_filename]\n"
               "\nExample: make_gaussian_filter "
               "IMG-HH-ALPSRP211830620-H1.0__A.PRM 2 4 200\n"
               "\nOutput: gauss_200\n";
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
 	double c_speed = 299792458.0;
 	double sig_azi, sig_rng, a, rng, cost, cosa;
 	double g[50][50];
-	char out_name[100] = "gauss_";
+	char out_name[128] = "gauss_";
 
 	if (argc < 4)
 		die(USAGE, "");
@@ -92,6 +92,8 @@ int main(int argc, char **argv) {
 		n_rng = n_rng + 1;
 
 	strcat(out_name, argv[4]);
+	if (argc > 5)
+		snprintf(out_name, 128, "%s", argv[5]);
 
 	if ((fid = fopen(out_name, "w")) == NULL)
 		die("Couldn't open file: \n", out_name);

--- a/gmtsar/phasediff.c
+++ b/gmtsar/phasediff.c
@@ -56,7 +56,8 @@
 char *USAGE = "phasediff [GMTSAR] - Compute phase difference of two images\n\n"
               "\nUsage: "
               "phasediff ref.PRM rep.PRM [-topo topo_ra.grd] [-model "
-              "modelphase.grd]\n (topo_ra and model in GMT grd format)\n";
+              "modelphase.grd] [-imag imag.grd] [-real real.grd]\n"
+              "(topo_ra and model in GMT grd format)\n";
 
 /*--------------------------------------------------------------*/
 void calc_drho(int xdim, double *range, double *topo, double avet, double re, double height, double B, double alpha, double Bx,
@@ -161,7 +162,8 @@ void fix_prm_params(struct PRM *p, char *s) {
 /*--------------------------------------------------------------*/
 /* read topo_ra and model files if provided			*/
 /* must be in GMT binary grd format					*/
-void read_optional_args(void *API, int argc, char **argv, struct PRM *tp, int *topoflag, struct PRM *mp, int *modelflag) {
+void read_optional_args(void *API, int argc, char **argv, struct PRM *tp, int *topoflag, struct PRM *mp, int *modelflag,
+			char *imag_filename, char *real_filename) {
 	int i;
 	struct GMT_GRID *M = NULL, *T = NULL; /* Grid structures containing ->header and ->data */
 
@@ -191,6 +193,14 @@ void read_optional_args(void *API, int argc, char **argv, struct PRM *tp, int *t
 			i++;
 			GMT_Destroy_Data(API, &M);
 		}
+
+		if (strncmp(argv[i], "-imag", strlen("-imag")) == 0) {
+			snprintf(imag_filename, 128, "%s", argv[i + 1]);
+		}
+
+		if (strncmp(argv[i], "-real", strlen("-real")) == 0) {
+			snprintf(real_filename, 128, "%s", argv[i + 1]);
+		}
 	}
 }
 
@@ -216,6 +226,8 @@ int main(int argc, char **argv) {
 	double ys, test, inc[2], wesn[4];
 	double xdect, ydect, xdecm, ydecm, rdumt;
 	FILE *SLCfile1 = NULL, *SLCfile2 = NULL;
+	char imag_filename[128] = "imag.grd=bf";
+	char real_filename[128] = "real.grd=bf";
 	fcomplex *intfp = NULL, *iptr1 = NULL, *iptr2 = NULL, pshif;
 	struct PRM p1, p2, tp, mp;
 	void *API = NULL;                       /* GMT control structure */
@@ -246,7 +258,7 @@ int main(int argc, char **argv) {
 		fprintf(stderr, "near range: %lf %lf \n", p1.near_range, p2.near_range);
 
 	if (argc > 3)
-		read_optional_args(API, argc, argv, &tp, &topoflag, &mp, &modelflag);
+		read_optional_args(API, argc, argv, &tp, &topoflag, &mp, &modelflag, imag_filename, real_filename);
 
 	if (debug)
 		print_prm_params(p1, p2);
@@ -563,11 +575,11 @@ else {
 		}
 	}
 
-	if (GMT_Write_Data(API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_GRID_ALL, NULL, "real.grd=bf", RE)) {
-		die("Failed to update real.grd grid header", "");
+	if (GMT_Write_Data(API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_GRID_ALL, NULL, real_filename, RE)) {
+		die("Failed to update real.grd grid header", real_filename);
 	}
-	if (GMT_Write_Data(API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_GRID_ALL, NULL, "imag.grd=bf", IM)) {
-		die("Failed to update imag.grd grid header", "");
+	if (GMT_Write_Data(API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_GRID_ALL, NULL, imag_filename, IM)) {
+		die("Failed to update imag.grd grid header", imag_filename);
 	}
 
 	if (GMT_Destroy_Session(API))

--- a/gmtsar/phasediff_get_topo_phase.c
+++ b/gmtsar/phasediff_get_topo_phase.c
@@ -161,7 +161,8 @@ void fix_prm_params(struct PRM *p, char *s) {
 /*--------------------------------------------------------------*/
 /* read topo_ra and model files if provided			*/
 /* must be in GMT binary grd format					*/
-void read_optional_args(void *API, int argc, char **argv, struct PRM *tp, int *topoflag, struct PRM *mp, int *modelflag) {
+void read_optional_args(void *API, int argc, char **argv, struct PRM *tp, int *topoflag, struct PRM *mp, int *modelflag,
+			char *imag_filename, char *real_filename) {
 	int i;
 	struct GMT_GRID *M = NULL, *T = NULL; /* Grid structures containing ->header and ->data */
 
@@ -246,7 +247,7 @@ int main(int argc, char **argv) {
 		fprintf(stderr, "near range: %lf %lf \n", p1.near_range, p2.near_range);
 
 	if (argc > 3)
-		read_optional_args(API, argc, argv, &tp, &topoflag, &mp, &modelflag);
+		read_optional_args(API, argc, argv, &tp, &topoflag, &mp, &modelflag, NULL, NULL);
 
 	if (debug)
 		print_prm_params(p1, p2);

--- a/gmtsar/phasefilt.c
+++ b/gmtsar/phasefilt.c
@@ -180,7 +180,7 @@ int calc_corr(void *API, char *amp1, char *amp2, unsigned int xdim, unsigned int
 }
 
 int phasefilt_parse_command_line(char **a, int na, char *USAGE, char *sre, char *sim, float *alp, int *ps, char *amp1, char *amp2,
-                                 int *dflag, int *comflag) {
+                                 int *dflag, int *comflag, char *phasefilt, char *corrfilt) {
 	int n;
 	int flag[4];
 
@@ -255,6 +255,22 @@ int phasefilt_parse_command_line(char **a, int na, char *USAGE, char *sre, char 
 		else if (!strcmp(a[n], "-debug")) {
 			verbose = 1;
 			debug = 1;
+		}
+		else if (!strncmp(a[n], "-phasefilt", strlen("-phasefilt"))) {
+			n++;
+			if (n == na)
+				die(" no option after -phasefilt!\n", "");
+			strncpy(phasefilt, a[n], 256);
+			if (verbose)
+				fprintf(stderr, "phasefilt %s \n", phasefilt);
+		}
+		else if (!strncmp(a[n], "-corrfilt", strlen("-corrfilt"))) {
+			n++;
+			if (n == na)
+				die(" no option after -corrfilt!\n", "");
+			strncpy(corrfilt, a[n], 256);
+			if (verbose)
+				fprintf(stderr, "corrfilt %s \n", corrfilt);
 		}
 		else {
 			fprintf(stderr, " %s *** option not recognized ***\n\n", a[n]);
@@ -334,6 +350,8 @@ int main(int argc, char **argv) {
 	struct FCOMPLEX *data = NULL, *fdata = NULL, *patch0 = NULL, *patch1 = NULL;
 	char sre[256], sim[256];
 	char amp1[256], amp2[256];
+	char phasefilt[256] = "filtphase.grd";
+	char corrfilt[256] = "filtcorr.grd";
 
 	void *API = NULL;                                  /* GMT API control structure */
 	struct GMT_GRID *RE = NULL, *IM = NULL, *T = NULL; /* Grid structure containing ->header and ->data */
@@ -350,7 +368,7 @@ int main(int argc, char **argv) {
 	psize = 32;   /* size of patch  # changed from 64 */
 	alpha = 0.5f; /* exponent */
 	dflag = 0;    /* write out difference */
-	phasefilt_parse_command_line(argv, argc, USAGE, sre, sim, &alpha, &psize, amp1, amp2, &dflag, &comflag);
+	phasefilt_parse_command_line(argv, argc, USAGE, sre, sim, &alpha, &psize, amp1, amp2, &dflag, &comflag, phasefilt, corrfilt);
 
 	/* patch size 		*/
 	/* currently square 	*/
@@ -459,10 +477,10 @@ int main(int argc, char **argv) {
 	for (i = 0; i < T->header->nm; i++)
 		outphase[i] = atan2f(fdata[i].i, fdata[i].r);
 
-	write_grdfile(API, T, "filtphase.grd", "phasefilt", "phase", outphase, verbose);
+	write_grdfile(API, T, phasefilt, "phasefilt", "phase", outphase, verbose);
 
 	if (corrflag)
-		write_grdfile(API, T, "filtcorr.grd", "phasefilt", "corr", corr, verbose);
+		write_grdfile(API, T, corrfilt, "phasefilt", "corr", corr, verbose);
 
 	if (comflag) {
 		for (i = 0; i < T->header->nm; i++)


### PR DESCRIPTION
Hard-coded filenames is evil for interoperability. The patch replaces these by optional command-line arguments. These changes are work well for PyGMTSAR and can be easily checked in just one click by running the example PyGMTSAR notebooks on Google Colab.