### PR TITLE
Update to correct_insar_with_gnss and extract_one_time_series

### DIFF
--- a/gmtsar/csh/correct_insar_with_gnss.csh
+++ b/gmtsar/csh/correct_insar_with_gnss.csh
@@ -98,7 +98,7 @@ errormessage:
 #  now blockmedian and surface the data at this resolution
 #
   gmt blockmedian ins-gps_diff.rad -Rtmp.grd > tmp.rad
-  gmt surface tmp.rad -Rtmp.grd -Gtmp1.grd 
+  gmt surface tmp.rad -Rtmp.grd -T0.1 -Gtmp1.grd 
 #
 # ----------------------
 # FILTER THE CORRECTION GRID
@@ -113,7 +113,7 @@ errormessage:
   gmt grdfilter tmp1.grd -Dp -Fg17 -Gtmp2.grd
 #
 # upsample to the original size using gmt surface
-# gmt grd2xyz tmp2.grd | gmt surface -R$insar -T0.5 -Gcorrection.grd
+# gmt grd2xyz tmp2.grd | gmt surface -R$insar -T0.1 -Gcorrection.grd
 #
 # upsample to original grid size using grdsample instead
 echo "...using grdsample to upsample the correction grid..."

--- a/gmtsar/csh/correct_insar_with_gnss.csh
+++ b/gmtsar/csh/correct_insar_with_gnss.csh
@@ -112,10 +112,13 @@ errormessage:
 #
   gmt grdfilter tmp1.grd -Dp -Fg17 -Gtmp2.grd
 #
-# upsample to the original size
+# upsample to the original size using gmt surface
+# gmt grd2xyz tmp2.grd | gmt surface -R$insar -T0.5 -Gcorrection.grd
 #
-  gmt grdsample tmp2.grd -Gtmp3.grd
-  gmt grd2xyz tmp3.grd | gmt surface -R$insar -T0.5 -Gcorrection.grd
+# upsample to original grid size using grdsample instead
+echo "...using grdsample to upsample the correction grid..."
+set incre = `  gmt grdinfo -Cn $insar | awk '{printf "%d+n/%d+n \n",$9,$10}' `
+gmt grdsample tmp2.grd -I$incre -Gcorrection.grd
 #
 # ----------------------
 # PERFORM THE CORRECTION

--- a/gmtsar/csh/extract_one_time_series.csh
+++ b/gmtsar/csh/extract_one_time_series.csh
@@ -61,7 +61,7 @@ set ii = 1
 
 while ($ii <= $N)
   #set name = `echo $ii | awk '{printf("disp_%.3d.grd",$1)}'`
-  set name = `awk 'NR=='$ii'{print $1}' scene.tab | awk '{printf("disp_%d.grd",$1)}'`
+  set name = `awk 'NR=='$ii'{print $1}' $5 | awk '{printf("disp_%d.grd",$1)}'`
   echo "Working on date $name"
   gmt grdcut $name -Gtmp_cut.grd -R$RR
   gmt grdinfo tmp_cut.grd -L2 -C | awk '{print $12,$13}' >> $output


### PR DESCRIPTION
This changes the upsampling method in correct_insar_with_gnss.csh to using gmt grdsample instead of gmt surface. Also, there is a small edit to extract_one_time_series.csh that makes it more flexible when pulling information from the user-provided scene.tab file. 