### PR TITLE
Add CI test for GMTSAR

### DIFF
--- a/.github/workflows/gmtsar.yml
+++ b/.github/workflows/gmtsar.yml
@@ -1,0 +1,111 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: GMTSAR
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  S1A_Stack_CPGF_T173_Linux:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-22.04", "ubuntu-20.04", "ubuntu-18.04"]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install system dependencies
+      run: |
+        uname -a
+        # prepare system
+        sudo apt update
+        # https://github.com/gmtsar/gmtsar/wiki/GMTSAR-Wiki-Page
+        sudo apt install -y csh subversion autoconf libtiff5-dev libhdf5-dev wget
+        sudo apt install -y liblapack-dev
+        sudo apt install -y gfortran
+        sudo apt install -y g++
+        sudo apt install -y libgmt-dev
+        sudo apt install -y gmt-dcw gmt-gshhg
+        # gmt-gshhg-full should be installed automatically (it is required to use GMTSAR landmask)
+        sudo apt install -y gmt
+        # add missed package
+        sudo apt install -y make
+    - name: Compile GMTSAR
+      run: |
+        autoconf
+        ./configure --with-orbits-dir=/tmp CFLAGS='-z muldefs' LDFLAGS='-z muldefs'
+        make CFLAGS='-z muldefs' LDFLAGS='-z muldefs'
+        make install
+        # check installation
+        export PATH=$PATH:/home/runner/work/gmtsar/gmtsar/bin
+        echo "Start gmtsar_sharedir.csh"
+        gmtsar_sharedir.csh
+    - name: Cache dataset
+      uses: actions/cache@v3
+      with:
+        path: tests/S1A_Stack_CPGF_T173.tar.gz
+        key: S1A_Stack_CPGF_T173.tar.gz
+        restore-keys: S1A_Stack_CPGF_T173
+    - name: Download dataset
+      working-directory: tests
+      run: |
+        wget -c http://topex.ucsd.edu/gmtsar/tar/S1A_Stack_CPGF_T173.tar.gz
+        tar xvzf S1A_Stack_CPGF_T173.tar.gz -C .
+    - name: Run test
+      working-directory: tests
+      run: |
+        export PATH=$PATH:/home/runner/work/gmtsar/gmtsar/bin
+        ./README_prep.txt
+        ./README_proc.txt
+        ./README_sbas.txt
+
+  S1A_Stack_CPGF_T173_MacOS:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-12, macos-11]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install system dependencies
+      run: |
+        uname -a
+        # prepare system
+        brew install wget libtiff hdf5 gmt ghostscript autoconf
+    - name: Compile GMTSAR
+      run: |
+        autoconf
+        ./configure --with-orbits-dir=/tmp
+        make
+        make install
+        # check installation
+        export PATH=$PATH:/Users/runner/work/gmtsar/gmtsar/bin
+        echo "Start gmtsar_sharedir.csh"
+        gmtsar_sharedir.csh
+    - name: Cache dataset
+      uses: actions/cache@v3
+      with:
+        path: tests/S1A_Stack_CPGF_T173.tar.gz
+        key: S1A_Stack_CPGF_T173.tar.gz
+        restore-keys: S1A_Stack_CPGF_T173
+    - name: Download dataset
+      working-directory: tests
+      run: |
+        wget -c http://topex.ucsd.edu/gmtsar/tar/S1A_Stack_CPGF_T173.tar.gz
+        tar xvzf S1A_Stack_CPGF_T173.tar.gz -C .
+    - name: Run test
+      working-directory: tests
+      run: |
+        export PATH=$PATH:/Users/runner/work/gmtsar/gmtsar/bin
+        ./README_prep.txt
+        ./README_proc.txt
+        ./README_sbas.txt


### PR DESCRIPTION
Add CI tests to check GMTSAR compilation and installation on Ubuntu-22.04, Ubuntu-20.04, Ubuntu-18.04, MacOS-12, MacOS-11. Also, the test downloads the example S1A_Stack_CPGF_T173.tar.gz and unpack and launch all the scripts for the complete SBAS processing. That's possible to add the test results badge on the main repository page. The test workflow starts on every commit and pull request to master branch. Note: Ubuntu-18.04 support will be removed on 1 Apr 2023.