### PR TITLE
snaphu_interp.csh: apply landmask to correlation grid

### DIFF
--- a/gmtsar/csh/snaphu_interp.csh
+++ b/gmtsar/csh/snaphu_interp.csh
@@ -62,6 +62,10 @@ if (-f mask_def.grd) then
     cp mask_def.grd mask_def_patch.grd
   endif
   gmt grdmath corr_patch.grd mask_def_patch.grd MUL = corr_patch.grd $V
+  # if landmask is available - then mask out corr values higher than the corr threshold in the water areas
+  if (-f landmask_ra_patch.grd) then
+    gmt grdmath corr_patch.grd landmask_ra_patch.grd MUL = corr_patch.grd
+  endif
 endif
 
 #


### PR DESCRIPTION
Apply landmask to corr grd to weed out pixels that are above the corr threshold and are in the water regions