### PR TITLE
When det_stitch is enabled, in some scenarios, a partial gap could exist in the merged swath (merge_unwrap_geocode_tops.csh)

### DIFF
--- a/gmtsar/csh/merge_unwrap_geocode_tops.csh
+++ b/gmtsar/csh/merge_unwrap_geocode_tops.csh
@@ -84,14 +84,14 @@
     set nl = `wc -l $1 | awk '{print $1}'`
     if ($nl == 2) then
       set pth2 = `head -1 $1 | awk -F: '{print $1}'`
-      gmt grdcut $pth2"phasefilt.grd" -Z+N -Gtmp.grd
+      gmt grdcut $pth2"phasefilt.grd" -Z+n+N -Gtmp.grd
       set xm1 = `gmt grdinfo $pth2"phasefilt.grd" -C | awk '{print $3}'`
       set xc1 = `gmt grdinfo tmp.grd -C | awk '{print $3}'`
       set incx = `gmt grdinfo tmp.grd -C | awk '{print $8}'`
       set n12 = `echo $xm1 $xc1 $incx | awk '{printf("%d",($1-$2)/$3)}'`
  
       set pth2 = `tail -1 $1 | awk -F: '{print $1}'`
-      gmt grdcut $pth2"phasefilt.grd" -Z+N -Gtmp.grd
+      gmt grdcut $pth2"phasefilt.grd" -Z+n+N -Gtmp.grd
       set x01 = `gmt grdinfo tmp.grd -C | awk '{print $2}'`
       set incx = `gmt grdinfo tmp.grd -C | awk '{print $8}'`
       set n21 = `echo $x01 $incx | awk '{printf("%d",$1/$2)}'`
@@ -105,14 +105,14 @@
       rm tmp.grd
     else if ($nl == 3) then
       set pth2 = `head -1 $1 | awk -F: '{print $1}'`
-      gmt grdcut $pth2"phasefilt.grd" -Z+N -Gtmp.grd
+      gmt grdcut $pth2"phasefilt.grd" -Z+n+N -Gtmp.grd
       set xm1 = `gmt grdinfo $pth2/phasefilt.grd -C | awk '{print $3}'`
       set xc1 = `gmt grdinfo tmp.grd -C | awk '{print $3}'`
       set incx = `gmt grdinfo tmp.grd -C | awk '{print $8}'`
       set n12 = `echo $xm1 $xc1 $incx | awk '{printf("%d",($1-$2)/$3)}'`
 
       set pth2 = `head -2 $1 | tail -1 | awk -F: '{print $1}'`
-      gmt grdcut $pth2"phasefilt.grd" -Z+N -Gtmp.grd
+      gmt grdcut $pth2"phasefilt.grd" -Z+n+N -Gtmp.grd
       set x02 = `gmt grdinfo tmp.grd -C | awk '{print $2}'`
       set incx = `gmt grdinfo tmp.grd -C | awk '{print $8}'`
       set n21 = `echo $x02 $incx | awk '{printf("%d",$1/$2)}'`
@@ -122,7 +122,7 @@
       set n22 = `echo $xm2 $xc2 $incx | awk '{printf("%d",($1-$2)/$3)}'`
 
       set pth2 = `tail -1 $1 | awk -F: '{print $1}'`
-      gmt grdcut $pth2"phasefilt.grd" -Z+N -Gtmp.grd
+      gmt grdcut $pth2"phasefilt.grd" -Z+n+N -Gtmp.grd
       set x03 = `gmt grdinfo tmp.grd -C | awk '{print $2}'`
       set incx = `gmt grdinfo tmp.grd -C | awk '{print $8}'`
       set n31 = `echo $x03 $incx | awk '{printf("%d",$1/$2)}'`


### PR DESCRIPTION
When det_stitch is enabled: To avoid scenarios where the starting column of the swath is partially NaNs and partially valid data results in a partial gap in the merged swath (see below), the +n option in the grdcut strips away NaNs from the grd file and avoids the partial gap problem in the merged swath.
![image](https://user-images.githubusercontent.com/25990795/217582138-89b72d29-94cf-49d9-b785-dca8070dc627.png)
