### PR TITLE
Update CI test

### DIFF
--- a/.github/workflows/gmtsar.yml
+++ b/.github/workflows/gmtsar.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "ubuntu-20.04", "ubuntu-18.04"]
+        os: ["ubuntu-22.04", "ubuntu-20.04"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -42,7 +42,7 @@ jobs:
       run: |
         autoconf
         ./configure --with-orbits-dir=/tmp CFLAGS='-z muldefs' LDFLAGS='-z muldefs'
-        make CFLAGS='-z muldefs' LDFLAGS='-z muldefs'
+        make
         make install
         # check installation
         export PATH=$PATH:/home/runner/work/gmtsar/gmtsar/bin

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![GMTSAR tests](https://github.com/gmtsar/gmtsar/actions/workflows/gmtsar.yml/badge.svg)](https://github.com/gmtsar/gmtsar/actions/workflows/gmtsar.yml)
+
 __INSTRUCTIONS FOR INSTALLING AND RUNNING GMTSAR__
 ----------------------------------------------
 


### PR DESCRIPTION
Update GMTSAR CI test and remove outdated Ubuntu 18 target (will be discontinued in the April). Add test badge on the main page.