### PR TITLE
Fix clean and spotless targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,4 +104,8 @@ spotless:
 		(cd preproc/$${d}_preproc; $(MAKE) spotless); \
 	done
 	rm -rf $(sharedir) bin share
+	$(RM) gmtsar/csh/gmtsar_sharedir.csh \
+	preproc/ENVI_preproc/scripts/ENVI_SLC_pre_process \
+	preproc/ENVI_preproc/scripts/ENVI_pre_process \
+	preproc/ERS_preproc/scripts/ERS_pre_process
 	rm -rf config.log config.status config.mk configure autom4te.cache

--- a/preproc/ALOS_preproc/ALOS_fbd2fbs/Makefile
+++ b/preproc/ALOS_preproc/ALOS_fbd2fbs/Makefile
@@ -19,4 +19,4 @@ uninstall:
 	rm -f $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)

--- a/preproc/ALOS_preproc/ALOS_fbd2fbs_SLC/Makefile
+++ b/preproc/ALOS_preproc/ALOS_fbd2fbs_SLC/Makefile
@@ -19,4 +19,4 @@ uninstall:
 	rm -f $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)

--- a/preproc/ALOS_preproc/ALOS_fbd2ss/Makefile
+++ b/preproc/ALOS_preproc/ALOS_fbd2ss/Makefile
@@ -19,4 +19,4 @@ uninstall:
 	rm -f $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)

--- a/preproc/ALOS_preproc/ALOS_merge/Makefile
+++ b/preproc/ALOS_preproc/ALOS_merge/Makefile
@@ -19,4 +19,4 @@ uninstall:
 	rm -f $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)

--- a/preproc/ALOS_preproc/ALOS_pre_process/Makefile
+++ b/preproc/ALOS_preproc/ALOS_pre_process/Makefile
@@ -23,4 +23,4 @@ uninstall:
 	rm -f $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)

--- a/preproc/ALOS_preproc/ALOS_pre_process_SLC/Makefile
+++ b/preproc/ALOS_preproc/ALOS_pre_process_SLC/Makefile
@@ -22,4 +22,4 @@ uninstall:
 	rm -f $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)

--- a/preproc/ALOS_preproc/ALOS_pre_process_SS/Makefile
+++ b/preproc/ALOS_preproc/ALOS_pre_process_SS/Makefile
@@ -21,4 +21,4 @@ uninstall:
 	rm -f $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)

--- a/preproc/CSK_preproc/src_raw/Makefile
+++ b/preproc/CSK_preproc/src_raw/Makefile
@@ -18,4 +18,4 @@ uninstall:
 	rm -f $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)

--- a/preproc/CSK_preproc/src_slc/Makefile
+++ b/preproc/CSK_preproc/src_slc/Makefile
@@ -18,4 +18,4 @@ uninstall:
 	rm -f $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)

--- a/preproc/ENVI_preproc/ASA_CAT/Makefile
+++ b/preproc/ENVI_preproc/ASA_CAT/Makefile
@@ -17,4 +17,4 @@ uninstall:
 	rm -f $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)

--- a/preproc/ENVI_preproc/Dop_orbit/Makefile
+++ b/preproc/ENVI_preproc/Dop_orbit/Makefile
@@ -19,4 +19,4 @@ uninstall:
 	rm -f $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)

--- a/preproc/ENVI_preproc/ENVI_decode/Makefile
+++ b/preproc/ENVI_preproc/ENVI_decode/Makefile
@@ -16,4 +16,4 @@ uninstall:
 	rm -f $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)

--- a/preproc/ERS_preproc/ers_line_fixer/Makefile
+++ b/preproc/ERS_preproc/ers_line_fixer/Makefile
@@ -13,7 +13,7 @@ $(PROG): $(OBJS)
 all:	$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core *.c.*
+	rm -f $(OBJS) tags core *.c.* $(PROG)
 
 install:
 	$(INSTALL) $(PROG) $(bindir)

--- a/preproc/ERS_preproc/read_data_file_ccrs/Makefile
+++ b/preproc/ERS_preproc/read_data_file_ccrs/Makefile
@@ -13,7 +13,7 @@ $(PROG): $(OBJS)
 all:	$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core *.c.*
+	rm -f $(OBJS) tags core *.c.* $(PROG)
 
 install:
 	$(INSTALL) $(PROG) $(bindir)/$(PROG)

--- a/preproc/ERS_preproc/read_data_file_dpaf/Makefile
+++ b/preproc/ERS_preproc/read_data_file_dpaf/Makefile
@@ -13,7 +13,7 @@ $(PROG): $(OBJS)
 all:	$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core *.c.*
+	rm -f $(OBJS) tags core *.c.* $(PROG)
 
 install:
 	$(INSTALL) $(PROG) $(bindir)

--- a/preproc/ERS_preproc/read_sarleader_dpaf/Makefile
+++ b/preproc/ERS_preproc/read_sarleader_dpaf/Makefile
@@ -11,7 +11,7 @@ $(PROG): $(OBJS)
 all:	$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)
 
 install:
 	$(INSTALL) $(PROG) $(bindir)

--- a/preproc/GF3_preproc/Makefile
+++ b/preproc/GF3_preproc/Makefile
@@ -25,3 +25,4 @@ clean:
 	done
 
 spotless:	clean
+	$(RM) lib include

--- a/preproc/GF3_preproc/src/Makefile
+++ b/preproc/GF3_preproc/src/Makefile
@@ -18,4 +18,4 @@ uninstall:
 	rm -f $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)

--- a/preproc/LT1_preproc/Makefile
+++ b/preproc/LT1_preproc/Makefile
@@ -25,3 +25,4 @@ clean:
 	done
 
 spotless:	clean
+	$(RM) lib include

--- a/preproc/LT1_preproc/src/Makefile
+++ b/preproc/LT1_preproc/src/Makefile
@@ -18,4 +18,4 @@ uninstall:
 	rm -f $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)

--- a/preproc/NSR_preproc/Makefile
+++ b/preproc/NSR_preproc/Makefile
@@ -27,3 +27,4 @@ clean:
 	done
 
 spotless:	clean
+	$(RM) lib include

--- a/preproc/NSR_preproc/src_slc/Makefile
+++ b/preproc/NSR_preproc/src_slc/Makefile
@@ -18,4 +18,4 @@ uninstall:
 	rm -f $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)

--- a/preproc/RS2_preproc/src/Makefile
+++ b/preproc/RS2_preproc/src/Makefile
@@ -18,4 +18,4 @@ uninstall:
 	rm -f $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)

--- a/preproc/S1A_preproc/Makefile
+++ b/preproc/S1A_preproc/Makefile
@@ -27,3 +27,4 @@ clean:
 	done
 
 spotless:	clean
+	$(MAKE) -C lib spotless

--- a/preproc/S1A_preproc/lib/Makefile
+++ b/preproc/S1A_preproc/lib/Makefile
@@ -19,3 +19,4 @@ clean:
 	rm -f *.o $(LIB)
 
 spotless:	clean
+	$(RM) lib

--- a/preproc/S1A_preproc/src_orbit/Makefile
+++ b/preproc/S1A_preproc/src_orbit/Makefile
@@ -18,4 +18,4 @@ uninstall:
 	rm $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)

--- a/preproc/S1A_preproc/src_swath/Makefile
+++ b/preproc/S1A_preproc/src_swath/Makefile
@@ -18,4 +18,4 @@ uninstall:
 	rm -f $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)

--- a/preproc/TSX_preproc/src/Makefile
+++ b/preproc/TSX_preproc/src/Makefile
@@ -18,4 +18,4 @@ uninstall:
 	rm -f $(bindir)/$(PROG)
 
 clean:
-	rm -f $(OBJS) tags core
+	rm -f $(OBJS) tags core $(PROG)


### PR DESCRIPTION
Improve the clean and spotless targets to ensure that the git checkout is totally clean (including ignored file) after a call to
```
make spotless
```