### PR TITLE
fix implicit declaration of function strdup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -349,7 +349,7 @@ if test "$GCC" = "yes"; then		# GNU cc options
 		CFLAGS="$CFLAGS -Wall"
 		CXXFLAGS="$CXXFLAGS -Wall"
 	fi
-	CFLAGS="$CFLAGS -fPIC -fno-strict-aliasing -std=c99"
+	CFLAGS="$CFLAGS -fPIC -fno-strict-aliasing -std=gnu99"
 	CXXFLAGS="$CXXFLAGS -fPIC"
 elif test "$os" = "SunOS" ; then	# Sun Workshop CC options
 	CFLAGS="$CFLAGS -Xc"


### PR DESCRIPTION
When I run it on a debian system, I find that an error is reported:

```
update_PRM_sub.c: In function ‘get_PRM’:      
update_PRM_sub.c:616:42: error: implicit declaration of function ‘strdup’; did you mean ‘strcmp’? [-Wimplicit-function-declaration]          
  616 |                         valuetype.name = strdup(lookuptable[n].name);              
      |                                          ^~~~~~
      |                                          strcmp
update_PRM_sub.c:616:40: error: assignment to ‘char *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
  616 |                         valuetype.name = strdup(lookuptable[n].name);
      |       
```
 I checked it on an ubuntu system, and the above content is considered a warning, as follows:
```
update_PRM_sub.c: In function 'get_PRM':
update_PRM_sub.c:616:42: warning: implicit declaration of function 'strdup'; did you mean 'strcmp'? [-Wimplicit-function-declaration]
  616 |                         valuetype.name = strdup(lookuptable[n].name);
      |                                          ^~~~~~
      |                                          strcmp
update_PRM_sub.c:616:40: warning: assignment to 'char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
  616 |                         valuetype.name = strdup(lookuptable[n].name);
      |                                        ^
```

If we use the gnu99 standard to build, it can be built normally on the debian system, and the above warning can also be resolved on the ubuntu system.