### PR TITLE
Add support for HDF5 2.1.0.

### DIFF
--- a/ax_lib_hdf5.m4
+++ b/ax_lib_hdf5.m4
@@ -226,7 +226,14 @@ HDF5 support is being disabled (equivalent to --with-hdf5=no).
           esac
         done
 
-        HDF5_LIBS="$HDF5_LIBS -lhdf5"
+        HDF5_INFIX=
+        case "$HDF5_LIBS" in
+            -lhdf5_*)
+                HDF5_INFIX="${HDF5_LIBS#-lhdf5_}"
+                HDF5_INFIX="_${HDF5_INFIX%%_*}"
+                ;;
+        esac
+        HDF5_LIBS="$HDF5_LIBS -lhdf5$HDF5_INFIX"
         AC_MSG_RESULT([yes (version $[HDF5_VERSION])])
 
         dnl See if we can compile
@@ -245,7 +252,7 @@ HDF5 support is being disabled (equivalent to --with-hdf5=no).
           AC_MSG_WARN([Unable to compile HDF5 test program])
         fi
         dnl Look for HDF5's high level library
-        AC_CHECK_LIB([hdf5_hl], [H5TBread_table], [HDF5_LIBS="$HDF5_LIBS -lhdf5_hl"], [], [])
+        AC_CHECK_LIB([hdf5${HDF5_INFIX}_hl], [H5TBread_table], [HDF5_LIBS="$HDF5_LIBS -lhdf5${HDF5_INFIX}_hl"], [], [])
 
         CC=$ax_lib_hdf5_save_CC
         CPPFLAGS=$ax_lib_hdf5_save_CPPFLAGS
@@ -281,9 +288,9 @@ HDF5 support is being disabled (equivalent to --with-hdf5=no).
             for arg in $HDF5_LIBS
             do
               case "$arg" in #(
-                -lhdf5_hl) HDF5_FLIBS="$HDF5_FLIBS -lhdf5hl_fortran $arg"
+                -lhdf5${HDF5_INFIX}_hl) HDF5_FLIBS="$HDF5_FLIBS -lhdf5${HDF5_INFIX}_hl_fortran $arg"
                   ;; #(
-                -lhdf5)    HDF5_FLIBS="$HDF5_FLIBS -lhdf5_fortran $arg"
+                -lhdf5${HDF5_INFIX})    HDF5_FLIBS="$HDF5_FLIBS -lhdf5${HDF5_INFIX}_fortran $arg"
                   ;; #(
                 *) HDF5_FLIBS="$HDF5_FLIBS $arg"
                   ;;

--- a/configure.ac
+++ b/configure.ac
@@ -153,7 +153,7 @@ dnl ------------------------------------------------------------------
 dnl Set the HDF5 include and lib stuff
 dnl ------------------------------------------------------------------
 AX_LIB_HDF5()
-HDF5_LIBS="$HDF5_LIBS -lhdf5_cpp"	# Add the C++ library
+HDF5_LIBS="$HDF5_LIBS -lhdf5${HDF5_INFIX}_cpp"	# Add the C++ library
 AC_MSG_CHECKING(for HDF5 include)
 AC_MSG_RESULT($HDF5_CPPFLAGS)
 AC_MSG_CHECKING(for HDF5 libs)


### PR DESCRIPTION
As reported by @pini-gh in [Debian Bug #1139600](https://bugs.debian.org/1139600):
> During a test rebuild of HDF5's reverse dependencies against HDF5 2.1.0 currently in experimental, gmtsar FTBFS because the related m4 macro doesn't support this new major release.
>
> The attached patch fixes this issue and support both HDF5 1.14.6 in unstable and HDF5 2.1.0 in experimental.
