### PR TITLE
gmtsar/python: framework update v2.8.0 → v2.12.0 (native Windows install + full conda toolchain isolation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 autom4te.cache/
 bin/
+build-win/
+dist/
+lib/
 config.log
 config.mk
 config.status

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (${srcdir} STREQUAL ${bindir})
 endif (${srcdir} STREQUAL ${bindir})
 
 # Define minimum CMake version required
-cmake_minimum_required (VERSION 2.8.5)
+cmake_minimum_required (VERSION 3.5)
 
 # Use NEW behavior with newer CMake releases
 foreach(p
@@ -62,8 +62,32 @@ include(ConfigureChecks)
 
 # Add subdirectories
 add_subdirectory (gmtsar)
-add_subdirectory (snaphu/src)
+if (EXISTS "${CMAKE_SOURCE_DIR}/snaphu/src/CMakeLists.txt")
+	add_subdirectory (snaphu/src)
+endif ()
 add_subdirectory (preproc)
+
+# Install the GMTSAR "sharedir" (filter kernels, snaphu configs, virgin PRM
+# templates) -- the CMake build's counterpart to the top-level Makefile's
+# `install:` target (see Makefile, sharedir rules). Only the traditional
+# ./configure && make path did this; the CMake path (gmtsar/CMakeLists.txt's
+# WIN32 block; this is Windows-only in practice today) never had an
+# equivalent, so filter/gmtsar_sharedir.csh-dependent tools (filter,
+# fitoffset, ...) had no share/gmtsar to resolve. Mirrors the Makefile's
+# file selection exactly: gmtsar/filters/[bfgsxy]* (kernel files), csh
+# snaphu.conf.* configs, and the two virgin PRM templates.
+install (DIRECTORY DESTINATION share/gmtsar/filters)
+install (DIRECTORY DESTINATION share/gmtsar/snaphu/config)
+file (GLOB _gmtsar_share_filters "${CMAKE_SOURCE_DIR}/gmtsar/filters/[bfgsxy]*")
+install (FILES ${_gmtsar_share_filters} DESTINATION share/gmtsar/filters)
+file (GLOB _gmtsar_share_snaphu_conf "${CMAKE_SOURCE_DIR}/gmtsar/csh/snaphu.conf.*")
+install (FILES ${_gmtsar_share_snaphu_conf} DESTINATION share/gmtsar/snaphu/config)
+file (GLOB _gmtsar_share_grds "${CMAKE_SOURCE_DIR}/gmtsar/*.grd")
+install (FILES
+	"${CMAKE_SOURCE_DIR}/preproc/ERS_preproc/scripts/virgin.PRM"
+	"${CMAKE_SOURCE_DIR}/preproc/ENVI_preproc/scripts/virgin_envisat.PRM"
+	${_gmtsar_share_grds}
+	DESTINATION share/gmtsar)
 
 # Configuration done
 message(

--- a/gmtsar/CMakeLists.txt
+++ b/gmtsar/CMakeLists.txt
@@ -2,6 +2,75 @@
 #	$Id$
 #
 
+if (WIN32)
+	# Real, confirmed-by-repro bug: LAPACK_LIBRARIES on Windows resolves to
+	# conda-forge's openblas.lib, which exports ~77,000 symbols. Linking
+	# ANY DLL against the full import library corrupts that DLL at
+	# runtime with this toolchain's old binutils (2.25.1 / GCC 5.3.0) --
+	# even calling a trivial unrelated function (e.g. reading its own
+	# 2nd string-pointer argument) inside that DLL segfaults. Isolated
+	# with a minimal repro (a one-line die(char*,char*) function crashes
+	# when its containing DLL links openblas.lib, but not when it links
+	# libtiff.lib or gmt.lib, and not when linked against a HAND-BUILT
+	# import lib exporting only the symbols actually used) -- looks like
+	# an IAT/thunk generation bug triggered by the sheer symbol count,
+	# not anything about GMTSAR/GMT/openblas's actual code.
+	#
+	# gmtsar only ever calls ONE LAPACK routine, dgelsy_ (sbas.c /
+	# sbas_utils.c; preproc/ doesn't link LAPACK at all) -- build a
+	# minimal import library exporting just that symbol against the
+	# real openblas.dll, sidestepping the huge-import-table trigger
+	# entirely instead of linking the full openblas.lib.
+	get_filename_component (_mingw_bin_dir "${CMAKE_C_COMPILER}" DIRECTORY)
+	find_program (DLLTOOL_EXECUTABLE dlltool HINTS "${_mingw_bin_dir}")
+	if (NOT DLLTOOL_EXECUTABLE)
+		message (FATAL_ERROR "dlltool not found -- needed to work around "
+			"the Windows openblas.lib linking bug (see comment above)")
+	endif ()
+	set (OPENBLAS_MIN_DEF "${CMAKE_CURRENT_BINARY_DIR}/openblas_min.def")
+	file (WRITE "${OPENBLAS_MIN_DEF}" "LIBRARY openblas.dll\nEXPORTS\ndgelsy_\n")
+	set (OPENBLAS_MIN_LIB "${CMAKE_CURRENT_BINARY_DIR}/libopenblas_min.dll.a")
+	add_custom_command (
+		OUTPUT "${OPENBLAS_MIN_LIB}"
+		COMMAND "${DLLTOOL_EXECUTABLE}" -d "${OPENBLAS_MIN_DEF}" -l "${OPENBLAS_MIN_LIB}" -D openblas.dll
+		DEPENDS "${OPENBLAS_MIN_DEF}"
+		COMMENT "Generating minimal openblas import lib (Windows linker workaround, see gmtsar/CMakeLists.txt)")
+	add_custom_target (openblas_min_lib_target DEPENDS "${OPENBLAS_MIN_LIB}")
+	set (LAPACK_LIBRARIES "${OPENBLAS_MIN_LIB}")
+endif (WIN32)
+
+if (WIN32)
+	# Real clean-machine failure (2026-07-24, fresh conda env on another
+	# host): find_package(TIFF REQUIRED) succeeded but left TIFF_LIBRARY
+	# empty, so TIFF silently vanished from GMTSAR_LINK_LIBS and the ONE
+	# executable calling libtiff directly (split_spectrum.c: TIFFOpen/
+	# TIFFReadScanline/...) failed at link with undefined references --
+	# every other target linked fine, hiding the root cause. conda-forge's
+	# libtiff has shipped its import library under both names
+	# (libtiff.lib and/or tiff.lib) across builds; coalesce explicitly
+	# and FAIL AT CONFIGURE TIME if nothing resolves, never link without
+	# TIFF silently. (Fresh cache var for the fallback: a stale
+	# TIFF_LIBRARY-NOTFOUND in CMakeCache.txt would otherwise pin the
+	# fallback search to its old failure.)
+	if (NOT TIFF_LIBRARY AND TIFF_LIBRARIES)
+		set (TIFF_LIBRARY ${TIFF_LIBRARIES})
+	endif ()
+	if (NOT TIFF_LIBRARY)
+		find_library (TIFF_LIBRARY_WIN_FALLBACK NAMES tiff libtiff)
+		if (TIFF_LIBRARY_WIN_FALLBACK)
+			set (TIFF_LIBRARY ${TIFF_LIBRARY_WIN_FALLBACK})
+		endif ()
+	endif ()
+	if (NOT TIFF_LIBRARY)
+		message (FATAL_ERROR "TIFF import library not found (checked "
+			"TIFF_LIBRARY, TIFF_LIBRARIES, and a direct search for "
+			"tiff.lib/libtiff.lib) -- refusing to configure a build that "
+			"would silently drop TIFF from the link line and fail only at "
+			"split_spectrum.exe's link step. Is libtiff installed in the "
+			"conda env this build is using?")
+	endif ()
+endif (WIN32)
+
 set (GMTSAR_LINK_LIBS ${GMT_LIBRARY} ${TIFF_LIBRARY} ${LAPACK_LIBRARIES})
 
 if (HAVE_M_LIBRARY)
@@ -11,6 +80,13 @@ endif (HAVE_M_LIBRARY)
 
 include_directories (${GMT_INCLUDE_DIR} ${TIFF_INCLUDE_DIR})
 
+if (WIN32)
+	# sbas_utils.c / resamp.c / sbas.c #include <sys/mman.h>, which MinGW
+	# doesn't provide -- a local mmap()/munmap() shim covers the subset
+	# they actually use (see compat_win32/sys/mman.h).
+	include_directories (${CMAKE_CURRENT_SOURCE_DIR}/compat_win32)
+endif (WIN32)
+
 add_library (gmtsar aastretch.c acpatch.c calc_dop.c conv2d.c do_freq_xcorr.c
 	do_time_int_xcorr.c fft_bins.c fft_interpolate_routines.c file_stuff.c
 	geoxyz.c get_locations.c get_params.c hermite_c.c highres_corr.c
@@ -18,9 +94,13 @@ add_library (gmtsar aastretch.c acpatch.c calc_dop.c conv2d.c do_freq_xcorr.c
 	polyfit.c print_results.c radopp.c read_orb.c read_xcorr_data.c
 	SAT_llt2rat_sub.c rmpatch.c rng_cmp.c rng_ref.c set_prm_defaults.c shift.c
 	sio_struct.c siocomplex.c spline.c trans_col.c utils.c utils_complex.c
-	write_orb.c sbas_utils.c gmtsar.h lib_functions.h llt2xyz.h orbit.h
+	write_orb.c sbas_utils.c stringutils.c update_PRM_sub.c rng_filter.c
+	lib_strfuncs.c gmtsar.h lib_functions.h llt2xyz.h orbit.h
 	sarleader_ALOS.h sarleader_fdr.h sfd_complex.h siocomplex.h soi.h xcorr.h)
 target_link_libraries (gmtsar ${GMTSAR_LINK_LIBS})
+if (WIN32)
+	add_dependencies (gmtsar openblas_min_lib_target)
+endif (WIN32)
 
 set (GMTSAR_LINK_LIBS ${GMTSAR_LINK_LIBS} gmtsar)
 
@@ -69,11 +149,52 @@ target_link_libraries (SAT_look ${GMTSAR_LINK_LIBS})
 add_executable (sbas sbas.c gmtsar.h sbas.h)
 target_link_libraries (sbas ${GMTSAR_LINK_LIBS})
 
+add_executable (update_PRM update_PRM.c update_PRM.h gmtsar.h)
+target_link_libraries (update_PRM ${GMTSAR_LINK_LIBS})
+
+add_executable (get_PRM get_PRM.c update_PRM.h)
+target_link_libraries (get_PRM ${GMTSAR_LINK_LIBS})
+
+add_executable (nearest_grid nearest_grid.c gmtsar.h)
+target_link_libraries (nearest_grid ${GMTSAR_LINK_LIBS})
+
+add_executable (fitoffset fitoffset.c update_PRM.h)
+target_link_libraries (fitoffset ${GMTSAR_LINK_LIBS})
+if (WIN32)
+	# fitoffset.c is the only file calling getline(), a glibc/POSIX
+	# extension the mingw-w64 runtime doesn't provide (see
+	# compat_win32/getline_shim.h). Force-include the shim for this one
+	# target only, instead of editing the upstream .c file.
+	target_compile_options (fitoffset PRIVATE
+		-include "${CMAKE_CURRENT_SOURCE_DIR}/compat_win32/getline_shim.h")
+endif (WIN32)
+
+add_executable (solid_tide solid_tide.c lib_functions.h)
+target_link_libraries (solid_tide ${GMTSAR_LINK_LIBS})
+
+add_executable (p_scatter p_scatter.c gmtsar.h)
+target_link_libraries (p_scatter ${GMTSAR_LINK_LIBS})
+
+add_executable (split_spectrum split_spectrum.c gmtsar.h)
+target_link_libraries (split_spectrum ${GMTSAR_LINK_LIBS})
+
+add_executable (cut_slc cut_slc.c gmtsar.h)
+target_link_libraries (cut_slc ${GMTSAR_LINK_LIBS})
+
+add_executable (split_aperture split_aperture.c gmtsar.h)
+target_link_libraries (split_aperture ${GMTSAR_LINK_LIBS})
+
+add_executable (phasediff_get_topo_phase phasediff_get_topo_phase.c gmtsar.h)
+target_link_libraries (phasediff_get_topo_phase ${GMTSAR_LINK_LIBS})
+
+add_executable (geocode_slc geocode_slc.c gmtsar.h llt2xyz.h orbit.h)
+target_link_libraries (geocode_slc ${GMTSAR_LINK_LIBS})
+
 add_executable (xcorr xcorr.c gmtsar.h)
 target_link_libraries (xcorr ${GMTSAR_LINK_LIBS})
 
 # add the install targets
-install (TARGETS gmtsar bperp calc_dop_orb conv esarp extend_orbit make_gaussian_filter offset_topo phase2topo phasediff phasefilt resamp SAT_baseline SAT_llt2rat SAT_look sbas xcorr
+install (TARGETS gmtsar bperp calc_dop_orb conv esarp extend_orbit make_gaussian_filter offset_topo phase2topo phasediff phasefilt resamp SAT_baseline SAT_llt2rat SAT_look sbas xcorr update_PRM get_PRM nearest_grid fitoffset solid_tide p_scatter split_spectrum cut_slc split_aperture phasediff_get_topo_phase geocode_slc
 	ARCHIVE DESTINATION lib
 	COMPONENT Runtime
 	LIBRARY DESTINATION lib

--- a/gmtsar/compat_win32/getline_shim.h
+++ b/gmtsar/compat_win32/getline_shim.h
@@ -1,0 +1,49 @@
+/* getline() shim for native Windows (MinGW) builds, where the mingw-w64
+ * runtime does not export this glibc/POSIX extension (declared by some
+ * mingw stdio.h versions, but not linkable -- "undefined reference").
+ * Only fitoffset.c uses it. Force-included via that target's
+ * target_compile_options(-include ...) in gmtsar/CMakeLists.txt, rather
+ * than editing fitoffset.c itself, to keep upstream .c files untouched
+ * (see gmtsar/compat_win32/sys/mman.h for the same convention).
+ */
+#ifndef GMTSAR_COMPAT_WIN32_GETLINE_SHIM_H
+#define GMTSAR_COMPAT_WIN32_GETLINE_SHIM_H
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static __inline ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
+    if (!lineptr || !n || !stream)
+        return -1;
+
+    if (!*lineptr || *n == 0) {
+        *n = 128;
+        *lineptr = (char *)malloc(*n);
+        if (!*lineptr)
+            return -1;
+    }
+
+    size_t pos = 0;
+    int c;
+    while ((c = fgetc(stream)) != EOF) {
+        if (pos + 1 >= *n) {
+            size_t new_size = *n * 2;
+            char *new_ptr = (char *)realloc(*lineptr, new_size);
+            if (!new_ptr)
+                return -1;
+            *lineptr = new_ptr;
+            *n = new_size;
+        }
+        (*lineptr)[pos++] = (char)c;
+        if (c == '\n')
+            break;
+    }
+
+    if (pos == 0 && c == EOF)
+        return -1;
+
+    (*lineptr)[pos] = '\0';
+    return (ssize_t)pos;
+}
+
+#endif /* GMTSAR_COMPAT_WIN32_GETLINE_SHIM_H */

--- a/gmtsar/compat_win32/sys/mman.h
+++ b/gmtsar/compat_win32/sys/mman.h
@@ -1,0 +1,54 @@
+/* Minimal mmap()/munmap() shim for native Windows (MinGW) builds, where
+ * <sys/mman.h> does not exist. Only the subset gmtsar's sbas_utils.c,
+ * resamp.c and sbas.c actually use: PROT_READ/PROT_WRITE, MAP_SHARED,
+ * mmap() over a file descriptor, munmap(). Implemented on top of
+ * CreateFileMapping/MapViewOfFile via _get_osfhandle(fd).
+ */
+#ifndef GMTSAR_COMPAT_WIN32_SYS_MMAN_H
+#define GMTSAR_COMPAT_WIN32_SYS_MMAN_H
+
+#include <io.h>
+/* Exclude winsock.h -- it declares its own connect(), which collides with
+ * gmtsar's unrelated SBAS graph-connectivity function of the same name in
+ * sbas.c/sbas_utils.c. This shim only needs the file-mapping API. */
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#define PROT_READ  0x1
+#define PROT_WRITE 0x2
+#define MAP_SHARED 0x01
+#define MAP_FAILED ((void *)-1)
+
+static __inline void *mmap(void *addr, size_t length, int prot, int flags,
+                            int fd, long offset) {
+    (void)addr;
+    (void)flags;
+    HANDLE file = (HANDLE)_get_osfhandle(fd);
+    if (file == INVALID_HANDLE_VALUE)
+        return MAP_FAILED;
+
+    DWORD protect = (prot & PROT_WRITE) ? PAGE_READWRITE : PAGE_READONLY;
+    DWORD access = (prot & PROT_WRITE) ? FILE_MAP_WRITE : FILE_MAP_READ;
+
+    HANDLE mapping = CreateFileMapping(file, NULL, protect, 0, 0, NULL);
+    if (mapping == NULL)
+        return MAP_FAILED;
+
+    void *view = MapViewOfFile(mapping, access, 0,
+                                (DWORD)(offset & 0xffffffff), length);
+    /* The mapping handle isn't needed once the view exists -- Windows
+     * keeps it alive internally until UnmapViewOfFile(). */
+    CloseHandle(mapping);
+    if (view == NULL)
+        return MAP_FAILED;
+    return view;
+}
+
+static __inline int munmap(void *addr, size_t length) {
+    (void)length;
+    return UnmapViewOfFile(addr) ? 0 : -1;
+}
+
+#endif /* GMTSAR_COMPAT_WIN32_SYS_MMAN_H */

--- a/gmtsar/csh/CMakeLists.txt
+++ b/gmtsar/csh/CMakeLists.txt
@@ -1,17 +1,17 @@
 configure_file (gmtsar_sharedir.csh.in gmtsar_sharedir.csh)
 
 install (PROGRAMS align.csh align_ALOS2_SCAN.csh align_ALOS_SLC.csh align_batch.csh align_batch_ALOS2_SCAN.csh
-	align_batch_ALOS_SLC.csh align_tops.csh align_tops_6par.csh align_tops_esd.csh baseline_table.csh
-	cleanup.csh create_frame_tops.csh dem2topo_ra.csh dem2topo_ra_ALOS2.csh detrend_before_unwrap.csh
+	align_batch_ALOS_SLC.csh align_tops.csh align_tops_esd.csh baseline_table.csh
+	cleanup.csh create_frame_tops.csh dem2topo_ra.csh dem2topo_ra_ALOS2.csh
 	filter.csh fitoffset.csh geocode.csh gmtsar.csh ${CMAKE_CURRENT_BINARY_DIR}/gmtsar_sharedir.csh
 	grd2geotiff.csh grd2kml.csh intf.csh
 	intf_batch.csh intf_batch_ALOS2_SCAN.csh intf_tops.csh landmask.csh landmask_ALOS2.csh m2s.csh
-	make_a_offset.csh make_dem.csh make_los_ascii.csh make_profile.csh merge_batch.csh
+	make_a_offset.csh make_dem.csh make_los_ascii.csh merge_batch.csh
     merge_unwrap_geocode_tops.csh p2p_ALOS2_SCAN_Frame.csh p2p_ALOS2_SCAN_SLC.csh
-	p2p_ENVI.csh p2p_ERS.csh p2p_S1_TOPS.csh p2p_S1_TOPS_Frame.csh pre_proc.csh pre_proc_batch.csh
-	pre_proc_batch_ALOS2_SCAN.csh pre_proc_batch_ALOS_SLC.csh pre_proc_init.csh preproc_batch_tops.csh
+	p2p_ENVI.csh p2p_ERS.csh p2p_S1_TOPS_Frame.csh pre_proc.csh pre_proc_batch.csh
+	pre_proc_batch_ALOS2_SCAN.csh pre_proc_batch_ALOS_SLC.csh preproc_batch_tops.csh
 	preproc_batch_tops_esd.csh proj_ll2ra.csh proj_ll2ra_ascii.csh proj_model.csh proj_ra2ll.csh
-	proj_ra2ll_ascii.csh sarp.csh slc2amp.csh snaphu.csh snaphu_interp.csh stack.csh stack_corr.csh 
-	update_PRM.csh select_pairs.csh
+	proj_ra2ll_ascii.csh sarp.csh slc2amp.csh snaphu.csh snaphu_interp.csh stack.csh stack_corr.csh
+	select_pairs.csh
 	DESTINATION bin
 	COMPONENT Runtime)

--- a/gmtsar/python/CLAUDE.md
+++ b/gmtsar/python/CLAUDE.md
@@ -35,7 +35,7 @@ Layout under `gmtsar/python/`:
 - `utils/tkGUI.gmtsar` — Tk GUI front-end
 - `tests/` — regression-test framework (`sweep.py`, `case_runner.py`, `compare.py`, `cases.py`, `run_one.sh`) plus `tests/configs/<case>.py` (staged Python configs translated from bundled csh `config*.txt`) and `tests/recipes/README_<case>.txt` (per-case recipes). The old `sweep.sh`/`case_runner.sh`/`runner.py` bash implementation is archived at `tests/archive/` (2026-07-13 rewrite — real CLI args instead of shell env vars; see `tests/archive/README.md`).
 - `docs/` — release notes archive (`release_notes_v*.md`)
-- Install script: `install.py` (`--system ubuntu|conda` installs everything for that system — deps, Python packages, build; `--rebuild` and `--orbits` are optional add-ons). Old bash version archived at `archive/install.sh` (2026-07-13 rewrite — real CLI args instead of shell env vars; see `archive/README.md`).
+- Install script: `install.py` (`--system ubuntu|conda|conda-linux-full|conda-windows-full` installs everything for that system — deps, Python packages, build; `--rebuild` and `--orbits` are optional add-ons). `conda-linux-full` additionally provisions the compiler/build-tool chain via conda (Linux x86_64 only). `conda-windows-full` is native Windows — no WSL, no MSYS2/Cygwin toolchain — still requires Git for Windows for `gmtsar_lib.py`'s POSIX-shell routing. Old bash version archived at `archive/install.sh` (2026-07-13 rewrite — real CLI args instead of shell env vars; see `archive/README.md`).
 
 ## Syncing from upstream
 

--- a/gmtsar/python/README.md
+++ b/gmtsar/python/README.md
@@ -62,17 +62,34 @@ One command, one installer: `gmtsar/python/install.py`. It builds gmtsar **in-pl
 # Ubuntu (sudo, apt-installs everything):
 python3 gmtsar/python/install.py --system ubuntu
 
-# Any Linux with an existing Miniconda/Anaconda install (no sudo; creates
-# the conda env for you if it doesn't exist yet):
+# Any platform with an existing Miniconda/Anaconda install (no sudo;
+# creates the conda env for you if it doesn't exist yet). Assumes the
+# system already has gfortran/g++/make/autoconf/csh/ghostscript:
 python3 gmtsar/python/install.py --system conda
+
+# Linux x86_64 only: like --system conda, but the compiler/build-tool
+# chain is ALSO conda-provided -- no system packages required at all
+# beyond a bare conda/miniconda install:
+python3 gmtsar/python/install.py --system conda-linux-full
+
+# Native Windows (no WSL, no MSYS2/Cygwin toolchain, no admin rights).
+# Requires Git for Windows (for a real POSIX shell -- gmtsar_lib.py
+# shells out via Git Bash) and an existing Miniconda/Anaconda install;
+# creates the conda env for you if it doesn't exist yet, including the
+# Windows-native build toolchain (m2w64-toolchain, cmake, ninja).
+# NOTE: `python`, not `python3` -- an Anaconda Prompt has no python3
+# alias (the install itself creates a python3.exe shim inside the env,
+# but that only exists AFTER this command has run):
+python gmtsar/python/install.py --system conda-windows-full
 ```
 
 That's it for a first install — it installs system deps, Python packages, and builds, in one step. Then export the env vars it prints at the end:
 ```
 export GMTSAR=<this repo>
 export PATH=$GMTSAR/bin:$PATH
-conda activate gmtsar   # --system conda only; --system ubuntu already has gmt on PATH
+conda activate gmtsar   # --system conda/conda-linux-full/conda-windows-full only; --system ubuntu already has gmt on PATH
 ```
+(`--system conda-windows-full` prints the Windows equivalents -- `set`/`$env:` -- instead.)
 
 Sanity check:
 ```
@@ -85,7 +102,7 @@ Iterating on source later (skip the dependency steps, just rebuild):
 python3 gmtsar/python/install.py --system conda --rebuild
 ```
 
-Other flags: `--conda-env <name>` (default env name `gmtsar`), `--orbits` (fetch the ~5-7 GB `ORBITS.tar`, optional, can run alone). Run `install.py --help` for full details. (Old bash version archived at `gmtsar/python/archive/install.sh`.)
+Other flags: `--conda-env <name>` (default env name `gmtsar`; pass `current` to install directly into whatever conda env is already active in your shell instead of creating/using a separate `gmtsar`-named env), `--orbits` (fetch the ~5-7 GB `ORBITS.tar`, optional, can run alone). Run `install.py --help` for full details. (Old bash version archived at `gmtsar/python/archive/install.sh`.)
 
 Every run writes a full, timestamped log — every command, real output, elapsed time, exit code — to `gmtsar/python/install_logs/install_<UTC timestamp>.log` (path also printed at the end), so a failure can be traced without re-running.
 
@@ -123,6 +140,8 @@ python3 gmtsar/python/tests/sweep.py --fast --cases RS2_SLC_Hawaii   # single ca
 
 Force a re-run of an already-passing (cached) case: `--force` (hard: wipe csh+python+results), `--force py` (soft: wipe only python_test+results, keep the csh oracle), `--force stage` (wipe only stage-cache sentinels).
 
+**Windows (`--system conda-windows-full`)**: no `csh`/`tcsh` interpreter exists for native Windows, so the normal py-vs-csh sweep can't run there at all -- use `--topo-mode-ab` (see below) instead, which needs no csh.
+
 Inside one sweep: each case runs in its own background subprocess (`subprocess.run(..., start_new_session=True)` inside `case_runner.py`, invoked by a bounded `threading.Semaphore` pool in `sweep.py`); within a case, csh and python recipes run in parallel threads. Cap concurrent cases with `--parallel N` (default 12). `compare.py` is invoked in-process via `runpy` after all cases finish.
 
 `--topo-mode-ab` repurposes the same tree-pair machinery for a `topo_interp_mode=0` vs `=1` A/B comparison (both sides run the Python recipe, no csh) — folders are named `ref_test`/`new_test` in that mode instead of `csh_test`/`python_test`.
@@ -147,7 +166,7 @@ A frozen-csh reference can be optionally produced via `tests/freeze_reference.py
 
 ## Notes on the framework
 1. Per-case computing time is collected in `<workdir>/timeSpentLog.txt`; stdout from each case is piped to `log.txt` in the case folder. A summary (wall-clock + per-pipeline timings) prints at the end of `sweep.py`.
-2. `tests/compare.py` does the comparison. Required Python packages are installed by `install.py --system {ubuntu,conda}`. Per-file thresholds live in `PNG_SSIM_THRESHOLD` / `GRD_RMS_THRESHOLD` dicts at the top of the script (phase-named outputs use a complex-domain rms metric that's invariant to 2π wraps).
+2. `tests/compare.py` does the comparison. Required Python packages are installed by `install.py --system {ubuntu,conda,conda-linux-full,conda-windows-full}`. Per-file thresholds live in `PNG_SSIM_THRESHOLD` / `GRD_RMS_THRESHOLD` dicts at the top of the script (phase-named outputs use a complex-domain rms metric that's invariant to 2π wraps).
 3. `tests/report.py` aggregates `results/*.json` and emits `<workdir>/sweep_summary.md`.
 4. The case manifest, tier membership, and `enabled` flags live in `tests/cases.py` (`CASES` dict).
 

--- a/gmtsar/python/bin_py/SAT_baseline_py
+++ b/gmtsar/python/bin_py/SAT_baseline_py
@@ -73,6 +73,12 @@ import numpy as np
 # utils/vector.py — those stay on the SourceFileLoader path below.
 _HERE = Path(__file__).resolve().parent
 _PY_ROOT = _HERE.parent
+if not (_PY_ROOT / "utils").is_dir() and os.environ.get("GMTSAR"):
+    # Windows staging COPIES this file flatly into bin/ (no symlink, see
+    # install.py's stage_execs) -- _HERE.parent then resolves to bin/..,
+    # which has no utils/ subdir. Fall back to the real source tree via
+    # $GMTSAR.
+    _PY_ROOT = Path(os.environ["GMTSAR"]) / "gmtsar" / "python"
 if str(_PY_ROOT) not in sys.path:
     sys.path.insert(0, str(_PY_ROOT))
 from utils.vector import (                                       # noqa: E402

--- a/gmtsar/python/bin_py/SAT_llt2rat_py
+++ b/gmtsar/python/bin_py/SAT_llt2rat_py
@@ -44,6 +44,12 @@ import numpy as np
 _HERE = Path(__file__).resolve().parent if "__file__" in globals() \
         else Path(os.path.abspath(sys.argv[0]) if sys.argv else os.getcwd()).resolve().parent
 _PY_ROOT = _HERE.parent
+if not (_PY_ROOT / "utils").is_dir() and os.environ.get("GMTSAR"):
+    # Windows staging COPIES this file flatly into bin/ (no symlink, see
+    # install.py's stage_execs) -- _HERE.parent then resolves to bin/..,
+    # which has no utils/ subdir. Fall back to the real source tree via
+    # $GMTSAR.
+    _PY_ROOT = Path(os.environ["GMTSAR"]) / "gmtsar" / "python"
 if str(_PY_ROOT) not in sys.path:
     sys.path.insert(0, str(_PY_ROOT))
 from utils.vector import (                                       # noqa: E402

--- a/gmtsar/python/bin_py/make_los_py
+++ b/gmtsar/python/bin_py/make_los_py
@@ -40,6 +40,7 @@ writes the output grd with the same coords / registration.
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -47,6 +48,12 @@ import numpy as np
 
 _HERE = Path(__file__).resolve().parent
 _UTILS = _HERE.parent / "utils"
+if not _UTILS.is_dir() and os.environ.get("GMTSAR"):
+    # Windows staging COPIES this file flatly into bin/ (no symlink, see
+    # install.py's stage_execs) -- _HERE.parent/"utils" then resolves to
+    # bin/../utils, which doesn't exist. Fall back to the real source
+    # tree via $GMTSAR.
+    _UTILS = Path(os.environ["GMTSAR"]) / "gmtsar" / "python" / "utils"
 if str(_UTILS) not in sys.path:
     sys.path.insert(0, str(_UTILS))
 

--- a/gmtsar/python/bin_py/make_slc_s1a_py
+++ b/gmtsar/python/bin_py/make_slc_s1a_py
@@ -19,7 +19,13 @@ from __future__ import annotations
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "utils"))
+_utils_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "utils")
+if not os.path.isdir(_utils_dir) and os.environ.get("GMTSAR"):
+    # Windows staging COPIES this file flatly into bin/ (no symlink, see
+    # install.py's stage_execs) -- ../utils then resolves to bin/../utils,
+    # which doesn't exist. Fall back to the real source tree via $GMTSAR.
+    _utils_dir = os.path.join(os.environ["GMTSAR"], "gmtsar", "python", "utils")
+sys.path.insert(0, _utils_dir)
 
 from s1a_preproc_lib import make_slc_s1a  # noqa: E402
 

--- a/gmtsar/python/bin_py/phasediff_py
+++ b/gmtsar/python/bin_py/phasediff_py
@@ -46,6 +46,12 @@ import numpy as np
 # Allow `from utils.gmt_grd_io import ...` regardless of cwd.
 _HERE = Path(__file__).resolve().parent
 _UTILS = _HERE.parent / "utils"
+if not _UTILS.is_dir() and os.environ.get("GMTSAR"):
+    # Windows staging COPIES this file flatly into bin/ (no symlink, see
+    # install.py's stage_execs) -- _HERE.parent/"utils" then resolves to
+    # bin/../utils, which doesn't exist. Fall back to the real source
+    # tree via $GMTSAR.
+    _UTILS = Path(os.environ["GMTSAR"]) / "gmtsar" / "python" / "utils"
 if str(_UTILS.parent) not in sys.path:
     sys.path.insert(0, str(_UTILS.parent))
 

--- a/gmtsar/python/bin_py/tests/test_install_config.py
+++ b/gmtsar/python/bin_py/tests/test_install_config.py
@@ -35,6 +35,42 @@ def test_hdf5_pinned_to_1_12_not_1_14_plus():
         "reintroduce the 1.14.x link failure")
 
 
+def _requirements_txt_lines():
+    req = install.REPO_ROOT / "gmtsar" / "python" / "requirements.txt"
+    return req.read_text().splitlines()
+
+
+def test_numpy_pinned_ge2_not_reverted():
+    """numpy<2 was pinned with NO documented reason (unlike every other
+    pin in requirements.txt) until a real external report (InSARHub,
+    a downstream consumer wanting numpy>=2 for its own dependencies)
+    prompted actually testing it instead of assuming it was needed.
+    Confirmed via a genuine clean-room build: fresh env, numpy 2.4.6,
+    full bin_py/tests/ suite (562 passed/59 skipped/0 failed) INCLUDING
+    the real C-vs-Python xcorr parity test against real data --
+    bit/float-exact, no numerical drift. See release_notes_v2.12.0.md."""
+    numpy_lines = [l for l in _requirements_txt_lines() if l.startswith("numpy")]
+    assert numpy_lines, "numpy must be pinned in requirements.txt"
+    assert numpy_lines[0].split()[0] == "numpy>=2", (
+        f"numpy pin changed to {numpy_lines[0]!r} -- if this reverts to "
+        "numpy<2 without a real reason, it silently drops a real, "
+        "tested compatibility improvement for downstream consumers")
+
+
+def test_numba_floor_ge_0_60_for_numpy2_abi():
+    """numba<0.60 caps numpy well below 2.0 in its own PyPI metadata
+    (0.56.4: numpy<1.24; 0.59.x: numpy<1.27) -- numba only gained real
+    numpy 2.x ABI support at 0.60.0. Doesn't bite in today's normal
+    resolve (nothing else forces an old numba), but a real risk in an
+    offline/locked install pinning numba<0.60 alongside numpy>=2."""
+    numba_lines = [l for l in _requirements_txt_lines() if l.startswith("numba")]
+    assert numba_lines, "numba must be pinned in requirements.txt"
+    assert numba_lines[0].split()[0] == "numba>=0.60", (
+        f"numba floor changed to {numba_lines[0]!r} -- if this drops "
+        "below 0.60 while numpy stays >=2, an offline/locked install "
+        "can silently pick a numpy2-incompatible numba")
+
+
 def test_flex_in_apt_system_deps():
     """preproc/ERS_preproc/ers_line_fixer/ers_line_fixer.l is the only
     .l/.y source in the repo and needs flex/lex to generate its .c file.
@@ -223,7 +259,11 @@ def test_pytest_in_requirements_txt():
     all without a manual `pip install pytest` -- requirements.txt never
     listed it, even though running that suite is part of the documented
     dev workflow (README.md's "Testing for developers")."""
-    requirements = (_UTILS / "requirements.txt").read_text()
+    # encoding pinned: read_text() without one uses the LOCALE codepage
+    # (e.g. GBK on a zh-locale Windows host), which chokes on this
+    # UTF-8 file's non-ASCII chars -- real failure hit 2026-07-23 on the
+    # conda-windows-full clean-room host.
+    requirements = (_UTILS / "requirements.txt").read_text(encoding="utf-8")
     assert re.search(r"^pytest\b", requirements, re.MULTILINE), (
         "pytest missing from requirements.txt -- a fresh install can't "
         "run its own test suite")
@@ -244,6 +284,15 @@ def test_locate_conda_env_creates_when_missing_at_resolved_base(tmp_path, monkey
 
     monkeypatch.setattr(install, "CONDA_SEARCH_BASES", [str(tmp_path / "unrelated")])
     monkeypatch.setattr(install, "locate_conda_base", lambda: fake_conda_base)
+    # Force the classic `conda create` path this test actually exercises --
+    # without this, a REAL micromamba on the test host's own PATH (installed
+    # separately, unrelated to this test) gets preferred by locate_conda_env's
+    # real logic, bypassing fake_run's `cmd[:2] == [conda_bin, "create"]`
+    # check entirely since the command becomes ["micromamba", "create", ...].
+    # Found as a genuine regression 2026-07-23 when a real clean-room
+    # test_install.py --full run hit this on a host that happened to have
+    # micromamba installed.
+    monkeypatch.setattr(install.shutil, "which", lambda name: None)
 
     calls = []
     def fake_run(cmd, **kwargs):
@@ -255,6 +304,41 @@ def test_locate_conda_env_creates_when_missing_at_resolved_base(tmp_path, monkey
     prefix = install.locate_conda_env("gmtsar_regress_test")
     assert prefix == fake_conda_base / "envs" / "gmtsar_regress_test"
     assert calls, "conda create was never invoked"
+    assert "conda-forge" in calls[0]
+
+
+def test_locate_conda_env_prefers_micromamba_when_present(tmp_path, monkeypatch):
+    """Real bug found 2026-07-23 (a genuine clean-room test_install.py
+    --full run): classic conda's solver hung 28+ minutes unsolved on
+    the real CONDA_FORGE_BOOTSTRAP_PACKAGES set on a host with an old,
+    pre-libmamba-solver conda. locate_conda_env() now prefers
+    micromamba for the actual create call when present on PATH."""
+    fake_conda_base = tmp_path / "fakeconda"
+    (fake_conda_base / "bin").mkdir(parents=True)
+    conda_bin = fake_conda_base / "bin" / "conda"
+    conda_bin.write_text("#!/bin/sh\necho fake\n")
+    conda_bin.chmod(0o755)
+    fake_micromamba = tmp_path / "fake_micromamba"
+    fake_micromamba.write_text("#!/bin/sh\necho fake\n")
+    fake_micromamba.chmod(0o755)
+
+    monkeypatch.setattr(install, "CONDA_SEARCH_BASES", [str(tmp_path / "unrelated")])
+    monkeypatch.setattr(install, "locate_conda_base", lambda: fake_conda_base)
+    monkeypatch.setattr(install.shutil, "which",
+                        lambda name: str(fake_micromamba) if name == "micromamba" else None)
+
+    calls = []
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[:1] == [str(fake_micromamba)]:
+            (fake_conda_base / "envs" / "gmtsar_mamba_test").mkdir(parents=True)
+    monkeypatch.setattr(install, "run", fake_run)
+
+    prefix = install.locate_conda_env("gmtsar_mamba_test")
+    assert prefix == fake_conda_base / "envs" / "gmtsar_mamba_test"
+    assert calls, "micromamba create was never invoked"
+    assert calls[0][0] == str(fake_micromamba)
+    assert "create" in calls[0]
     assert "conda-forge" in calls[0]
 
 

--- a/gmtsar/python/bin_py/tests/test_windows_port.py
+++ b/gmtsar/python/bin_py/tests/test_windows_port.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""test_windows_port.py — regression guards for the v2.10.x native-Windows
+port (`--system conda-windows-full`). Each test maps to a REAL bug found
+during the 2026-07-23 bring-up and the two clean-room runs that followed
+(fresh clone + fresh conda env) — see install.py / utils/gmtsar_lib.py /
+tests/case_runner.py comments and release_notes_v2.10.x.md for the full
+incident writeups. Per project_rules.md Rule 8, every one of those bugs
+gets a guard here so it can't silently ship again.
+
+All tests are static, mock-based, or tiny-fixture — no conda, no network,
+no Windows requirement (they run and pass on POSIX CI too; the
+Windows-only code paths are exercised via monkeypatched `os.name`).
+"""
+from __future__ import annotations
+
+import importlib
+import inspect
+import os
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+_PY_ROOT = Path(__file__).resolve().parent.parent.parent  # gmtsar/python
+for _p in (str(_PY_ROOT), str(_PY_ROOT / "utils"), str(_PY_ROOT / "tests")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import install  # noqa: E402
+import gmtsar_lib  # noqa: E402
+
+
+# ── install.py: fresh-env creation bugs (found by the 2026-07-23 clean room) ──
+
+def test_windows_bootstrap_includes_pip():
+    """Real bug (2026-07-23, first genuinely-fresh Windows env): python
+    arrives transitively (gmt -> gdal -> python bindings) but pip is not
+    guaranteed to, and do_python_deps runs `python.exe -m pip install`.
+    Same bug class CONDA_FORGE_BOOTSTRAP_PACKAGES fixed in v2.9.0."""
+    assert "pip" in install.WINDOWS_CONDA_BOOTSTRAP_PACKAGES
+
+
+def test_windows_conda_cmd_exe_is_direct_and_preserves_specs():
+    """Real bug (2026-07-23, first genuinely-fresh Windows env creation):
+    routing `conda create` through `cmd /c conda.bat` let cmd parse the
+    spec `libtiff>=4.5,<5` as redirection operators, failing in ms with
+    'The system cannot find the file specified'. conda.exe must be
+    invoked DIRECTLY (no cmd), with specs passed through untouched."""
+    spec = "libtiff>=4.5,<5"
+    cmd = install._windows_conda_cmd(Path("C:/fake/Scripts/conda.exe"),
+                                      ["create", "-n", "x", spec])
+    assert cmd[0] != "cmd", "conda.exe must not be routed through cmd /c"
+    assert spec in cmd, "package spec must pass through verbatim"
+
+
+def test_windows_conda_cmd_bat_fallback_rejects_metachars():
+    """The conda.bat fallback CANNOT pass cmd metacharacters reliably
+    (list2cmdline escapes embedded quotes as \\" which survive the .bat's
+    %* forwarding as literal quote chars) — it must fail loudly up front,
+    never let cmd silently misparse a spec into redirections."""
+    bat = Path("C:/fake/condabin/conda.bat")
+    with pytest.raises(SystemExit):
+        install._windows_conda_cmd(bat, ["create", "libtiff>=4.5,<5"])
+    # Metachar-free args are still allowed through the fallback:
+    cmd = install._windows_conda_cmd(bat, ["env", "list", "--json"])
+    assert cmd[:2] == ["cmd", "/c"]
+
+
+def test_windows_conda_exe_prefers_scripts_exe(tmp_path):
+    """Scripts\\conda.exe (real PE, directly CreateProcess-able, no cmd
+    parsing) must win over condabin\\conda.bat whenever it exists."""
+    (tmp_path / "Scripts").mkdir()
+    (tmp_path / "condabin").mkdir()
+    exe = tmp_path / "Scripts" / "conda.exe"
+    bat = tmp_path / "condabin" / "conda.bat"
+    exe.write_text("")
+    bat.write_text("")
+    assert install._windows_conda_exe(tmp_path) == exe
+    exe.unlink()
+    assert install._windows_conda_exe(tmp_path) == bat
+
+
+def test_apply_c_fixes_called_from_windows_build():
+    """Real gap (v2.10.0): _apply_c_fixes() was only called from
+    do_build(), so the Windows CMake path silently skipped both the
+    conv.c and fitoffset.c fixes until wired in explicitly."""
+    assert "_apply_c_fixes" in inspect.getsource(install.do_windows_build)
+
+
+# ── c_fixes/conv.c: binary reads must stay binary-mode ────────────────────────
+
+def test_conv_c_fix_staged_wired_and_binary_mode():
+    """Real bug (2026-07-23): conv.c opened the raw SLC and .grd=bf files
+    with fopen(..., "r") — text mode. On Windows the CRT translates CRLF
+    and treats 0x1A as EOF, silently corrupting the read; correlation
+    collapsed to ~0 over 85% of a real RS2 swath. Guard all three layers:
+    staged copy uses "rb", the C_FIXES map wires it, and no text-mode
+    variant of either call site sneaks back into the staged copy."""
+    src = _PY_ROOT / "c_fixes" / "conv.c"
+    assert src.is_file(), "c_fixes/conv.c staged copy missing"
+    text = src.read_text(encoding="utf-8")
+    assert 'fopen(input_file_name, "rb")' in text
+    assert 'fopen(input_name, "rb")' in text
+    assert 'fopen(input_file_name, "r")' not in text
+    assert 'fopen(input_name, "r")' not in text
+    assert any(s.name == "conv.c" for s in install.C_FIXES), \
+        "c_fixes/conv.c not wired into install.C_FIXES"
+
+
+# ── gmtsar_lib._win_bash(): resolution + thread-safety ───────────────────────
+
+@pytest.fixture
+def _reset_win_bash():
+    """Save/restore _win_bash's process-wide memoization around a test."""
+    saved = (gmtsar_lib._WIN_BASH, gmtsar_lib._WIN_BASH_RESOLVED)
+    gmtsar_lib._WIN_BASH = None
+    gmtsar_lib._WIN_BASH_RESOLVED = False
+    yield
+    gmtsar_lib._WIN_BASH, gmtsar_lib._WIN_BASH_RESOLVED = saved
+
+
+def test_win_bash_honors_env_override(_reset_win_bash, tmp_path, monkeypatch):
+    fake_bash = tmp_path / "bash.exe"
+    fake_bash.write_text("")
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setenv("GMTSAR_WIN_BASH", str(fake_bash))
+    assert gmtsar_lib._win_bash() == str(fake_bash)
+
+
+def test_win_bash_rejects_system32_wsl_stub(_reset_win_bash, monkeypatch):
+    """Real bug (2026-07-23): Windows 10+ ships a System32\\bash.exe stub
+    that launches WSL — a full recipe run silently no-opped against its
+    'no installed distributions' prompt while reporting success. When the
+    ONLY bash PATH offers is the System32 stub, resolution must refuse it
+    (and, with no other candidate existing, exit loudly)."""
+    stub = r"C:\Windows\System32\bash.exe"
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.delenv("GMTSAR_WIN_BASH", raising=False)
+    monkeypatch.setattr(gmtsar_lib.shutil, "which", lambda _: stub)
+    monkeypatch.setattr(gmtsar_lib.os.path, "isfile",
+                        lambda p: p == stub)  # ONLY the stub "exists"
+    with pytest.raises(SystemExit):
+        gmtsar_lib._win_bash()
+
+
+def test_win_bash_thread_safe_no_caller_sees_none(_reset_win_bash, tmp_path,
+                                                   monkeypatch):
+    """Real bug (2026-07-23): the memoization set its resolved flag BEFORE
+    assigning the value — a concurrent caller (case_runner runs two slot
+    threads per case) saw RESOLVED=True with the value still None and
+    silently fell through to cmd.exe ('cleanup' is not recognized...).
+    Invariant: once any caller gets a value, no concurrent caller may
+    ever observe None."""
+    fake_bash = tmp_path / "bash.exe"
+    fake_bash.write_text("")
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setenv("GMTSAR_WIN_BASH", str(fake_bash))
+    results = []
+    threads = [threading.Thread(target=lambda: results.append(gmtsar_lib._win_bash()))
+               for _ in range(16)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert len(results) == 16
+    assert all(r == str(fake_bash) for r in results), \
+        f"a concurrent caller observed a wrong value: {set(results)}"
+
+
+def test_resolve_sharedir_returns_forward_slashes(tmp_path, monkeypatch):
+    """Real bug (2026-07-23): a backslashed sharedir embedded unquoted in
+    a `bash -c` command string had its backslashes eaten by bash escaping
+    (D:\\...\\share\\gmtsar -> D:...sharegmtsar), so conv couldn't open
+    filter kernels. resolve_sharedir must emit forward slashes only."""
+    share = tmp_path / "share" / "gmtsar"
+    share.mkdir(parents=True)
+    monkeypatch.setenv("GMTSAR", str(tmp_path))
+    assert "\\" not in gmtsar_lib.resolve_sharedir()
+
+
+# ── tests/ harness: path-separator + tree-name bugs ──────────────────────────
+
+def test_case_runner_env_path_uses_os_pathsep():
+    """Real bug (2026-07-23): case_runner/sweep built PATH with a
+    hardcoded ':' — malformed on Windows (os.pathsep is ';')."""
+    import case_runner
+    env = case_runner._run_subprocess_env(None, "/fake/gmtsar/bin",
+                                           False, "case_x", None)
+    assert env["PATH"].split(os.pathsep)[0] == "/fake/gmtsar/bin"
+
+
+def test_cases_roots_survive_rstrip_basename_on_all_platforms(monkeypatch):
+    """Real bug (2026-07-23): tree roots were built as
+    `workAbsoluteDir + 'ref_test/'` — a literal '/' after an os.sep path.
+    On Windows, `.rstrip(os.sep)` then stripped nothing, basename()
+    returned '', and BOTH topo-mode-ab trees silently collapsed into the
+    same directory (two threads corrupting each other's outputs while
+    reporting success). Guard: for both TOPO_MODE_AB settings, every root
+    must end with os.sep and yield its expected non-empty dir name."""
+    import cases
+    try:
+        for ab_mode, expected in (
+            ("1", {"ref_test", "new_test", "dataset", "recipes"}),
+            (None, {"python_test", "csh_test", "dataset", "recipes"}),
+        ):
+            if ab_mode is None:
+                monkeypatch.delenv("TOPO_MODE_AB", raising=False)
+            else:
+                monkeypatch.setenv("TOPO_MODE_AB", ab_mode)
+            importlib.reload(cases)
+            roots = [cases.cshRefRoot, cases.pythonRunRoot,
+                     cases.datasetRoot, cases.recipesDir]
+            names = {os.path.basename(r.rstrip(os.sep)) for r in roots}
+            assert all(r.endswith(os.sep) for r in roots)
+            assert names == expected, f"tree-name derivation broke: {names}"
+    finally:
+        monkeypatch.delenv("TOPO_MODE_AB", raising=False)
+        importlib.reload(cases)
+
+
+def test_run_recipe_resolves_bash_via_win_bash():
+    """Real bug (2026-07-23): _run_recipe invoked a bare ["bash", ...],
+    trusting PATH order — the System32 WSL stub could (and did) win,
+    no-opping entire recipe runs. It must resolve via _win_bash()."""
+    import case_runner
+    assert "_win_bash" in inspect.getsource(case_runner._run_recipe)
+
+
+# ── distribute_gmtsar_windows.py: bundle-correctness guards (v2.10.3) ────────
+
+import distribute_gmtsar_windows as dist_mod  # noqa: E402
+
+
+def test_bootstrap_pins_openblas_blas_variant():
+    """Real bug (2026-07-23, isolated-PATH verify): conda-forge's win-64
+    default libblas/liblapack are MKL-variant forwarder shims; merely
+    co-installing openblas does NOT flip them, and MKL can't be bundled
+    (runtime dispatch). The variant pins are load-bearing."""
+    for pin in ("libblas=*=*openblas", "liblapack=*=*openblas",
+                "libcblas=*=*openblas"):
+        assert pin in install.WINDOWS_CONDA_BOOTSTRAP_PACKAGES
+
+
+def test_is_system_dll_policy():
+    """api-set names are virtual on Win10+ (never bundle); MSVC runtime
+    is NEVER system (presence in System32 only proves THIS machine has a
+    VC redist -- a clean target may not)."""
+    assert dist_mod._is_system_dll("api-ms-win-crt-math-l1-1-0.dll")
+    assert dist_mod._is_system_dll("ext-ms-win-anything.dll")
+    assert not dist_mod._is_system_dll("VCRUNTIME140.dll")
+    assert not dist_mod._is_system_dll("msvcp140.dll")
+
+
+@pytest.mark.skipif(os.name != "nt", reason="needs a real Windows system DLL")
+def test_pe_forwarder_targets_on_real_forwarders():
+    """kernel32.dll famously forwards a chunk of its exports to ntdll
+    (HeapAlloc -> NTDLL.RtlAllocateHeap, ...) -- a real, stable fixture
+    for the export-forwarder parser that found the MKL-shim bug."""
+    k32 = Path(os.environ["SystemRoot"]) / "System32" / "kernel32.dll"
+    targets = {t.lower() for t in dist_mod._pe_forwarder_targets(k32)}
+    assert "ntdll.dll" in targets
+
+
+def test_pe_forwarder_targets_tolerates_non_pe(tmp_path):
+    junk = tmp_path / "not_a_pe.dll"
+    junk.write_bytes(b"definitely not a PE file")
+    assert dist_mod._pe_forwarder_targets(junk) == set()
+
+
+def test_collect_dlls_walks_forwarders_and_guards_mkl():
+    src = inspect.getsource(dist_mod.do_collect_dlls)
+    assert "_pe_forwarder_targets" in src, \
+        "import-table-only walk misses forwarder deps (the MKL-shim bug)"
+    assert "mkl" in src, "MKL fail-loud guard removed"
+
+
+def test_launcher_template_contract():
+    """Each entry maps to a real bundle-smoke failure (2026-07-23):
+    gmt.exe lives in pyenv\Library\bin (rc=127 without it); the real
+    bash is usr\bin\bash.exe (Git\bin one is a launcher stub); the
+    gmt.dll copy in dist\bin has the BUILD env's share path baked in
+    (GMT_SHAREDIR must override)."""
+    t = dist_mod.LAUNCHER_TEMPLATE
+    assert r"pyenv\Library\bin" in t
+    assert r"git-bash\usr\bin\bash.exe" in t
+    assert "GMT_SHAREDIR" in t
+
+
+def test_bundle_includes_python_framework_tree():
+    """bin_py tools resolve their utils package via
+    $GMTSAR/gmtsar/python/utils -- the bundle must carry that tree or
+    every one of them ImportErrors (found by the first bundle smoke)."""
+    src = inspect.getsource(dist_mod.do_copy_gmtsar)
+    assert '"utils"' in src and '"bin_py"' in src
+
+
+def test_verify_harness_survives_stdin_readers():
+    """esarp.exe etc. block on stdin when invoked bare -- the verify must
+    close stdin and treat a long-running (started!) exe as pass, not
+    crash the whole run with TimeoutExpired."""
+    src = inspect.getsource(dist_mod.do_verify)
+    assert "DEVNULL" in src
+    assert "TimeoutExpired" in src
+
+
+def test_bundle_writes_license_attribution():
+    """Publishing the bundle zip redistributes GMT/LGPL, ghostscript/AGPL,
+    Git Bash/GPLv3, GMTSAR/GPL-3 -- the license-collation step is a
+    release blocker, not a nicety (flagged in PATHWAY_FORWARD v2.10.2/3,
+    closed in v2.11.0)."""
+    src = inspect.getsource(dist_mod.do_write_licenses)
+    for needle in ("THIRD_PARTY_NOTICES", "conda-meta", "AGPL", "LICENSE.TXT",
+                   "importlib.metadata",  # pip dists are NOT in conda-meta
+                   "license_texts"):      # verbatim copyleft texts, fail-loud
+        assert needle in src
+    assert "do_write_licenses" in inspect.getsource(dist_mod.main)
+    # The committed texts every copyleft component in the bundle requires
+    # (2026-07-23 audit): poppler GPL-2.0-only, gmt LGPL-3, geos LGPL-2.1,
+    # ghostscript AGPL-3, spatialite MPL-1.1, certifi MPL-2.0.
+    texts = _PY_ROOT / "license_texts"
+    for lic in ("GPL-2.0", "LGPL-2.1", "LGPL-3.0", "AGPL-3.0",
+                "MPL-1.1", "MPL-2.0"):
+        f = texts / f"{lic}.txt"
+        assert f.is_file() and f.stat().st_size > 5000, f"missing/stub {f}"
+
+
+def test_cmake_win32_tiff_coalesce_and_fail_loud():
+    """Real clean-machine failure (2026-07-24, another host's fresh conda
+    env): find_package(TIFF REQUIRED) left TIFF_LIBRARY empty, TIFF
+    silently dropped off GMTSAR_LINK_LIBS, and only split_spectrum.exe
+    (the sole direct libtiff consumer) failed at link -- undefined
+    TIFFOpen/TIFFReadScanline. gmtsar/CMakeLists.txt must coalesce
+    TIFF_LIBRARY from TIFF_LIBRARIES / a direct search, and FATAL_ERROR
+    at configure time rather than ever link without TIFF."""
+    cml = (_PY_ROOT.parent.parent / "gmtsar" / "CMakeLists.txt").read_text(encoding="utf-8")
+    assert "TIFF_LIBRARIES" in cml
+    assert "TIFF_LIBRARY_WIN_FALLBACK" in cml
+    assert "FATAL_ERROR" in cml and "TIFF import library not found" in cml

--- a/gmtsar/python/c_fixes/README.md
+++ b/gmtsar/python/c_fixes/README.md
@@ -1,0 +1,63 @@
+# c_fixes/ — real fixes to upstream `gmtsar/*.c`, staged here
+
+This directory holds corrected copies of files under `gmtsar/gmtsar/`
+(the real upstream C source, outside `gmtsar/python/`). Per this repo's
+"all dev work lives in `gmtsar/python/`, everything else is upstream and
+stays untouched for clean merges" rule, real fixes to upstream `.c` files
+are staged here first rather than applied directly at their original
+location.
+
+## fitoffset.c — strlcpy portability bug
+
+Found 2026-07-23 while clean-room testing full conda-toolchain isolation
+(conda-forge's own `gfortran_linux-64`/`gxx_linux-64` compiler packages,
+not the system compiler). `gmtsar/fitoffset.c` calls `strlcpy()` (a BSD
+function) without declaring or including it anywhere. This "works" —
+implicit-declaration is only a *warning* — on GCC < 14 (e.g. the
+system's Ubuntu 22.04 GCC 11.4.0, which `--system conda`'s existing
+install path deliberately uses instead of a conda-provided compiler).
+It's a **hard compile error** on GCC 14+ (conda-forge's compiler
+packages are GCC 15.2.0), which promoted implicit function declarations
+from warning to error by default as part of C23 alignment. Confirmed
+directly: same source, `-Werror` NOT passed, system gcc 11.4.0 →
+warning + successful link; conda gcc 15.2.0 → hard error.
+
+This is a real forward-compatibility bug independent of conda isolation
+-- it will also break `--system ubuntu` on any distro shipping GCC 14+
+(Ubuntu 24.10+, Fedora 40+, Arch already do).
+
+**Fix**: both call sites replace `strlcpy(dest, "literal", sizeof
+dest)` with `snprintf(dest, sizeof dest, "%s", "literal")` -- identical
+behavior for a fixed short literal into a `MAX_PATH`-sized buffer,
+zero new includes, no BSD-library dependency, compiles cleanly on every
+GCC version tested (11.4.0 and 15.2.0).
+
+Applied automatically at build time by `install.py`'s `_apply_c_fixes()`
+(copies each `C_FIXES` entry over its upstream target before `make`/
+CMake runs) -- not yet contributed upstream to the real
+`gmtsar/gmtsar/fitoffset.c`, but no longer inert either.
+
+## conv.c — binary file reads opened in text mode (Windows)
+
+Found 2026-07-23 while bringing up `--system conda-windows-full` (native
+Windows build, MinGW toolchain). `gmtsar/conv.c` opens the raw complex
+SLC file and the `.grd=bf` native-binary-float file with `fopen(path,
+"r")` -- **text mode**. On POSIX this is a no-op (`"r"` and `"rb"` are
+identical there), so the bug is invisible on Linux/macOS. On Windows,
+text mode makes the CRT translate `\r\n` -> `\n` on read AND treat byte
+`0x1A` as an EOF marker -- both of which silently corrupt/truncate a
+binary stream partway through the file. Confirmed as the root cause of
+a real symptom: interferogram correlation (`corr.grd`, `filter`'s
+`conv`-based amplitude/correlation formation) collapsing to
+near-zero over ~85% of a real RS2 pair's swath on Windows, while the
+identical Python framework code produced a near-machine-precision
+match to the C reference on Linux (`corr_ll.grd` RMS 1e-6 vs 4e-4)
+-- i.e. not a logic bug in the port, a Windows-only binary-mode bug in
+the C reader everything downstream depends on.
+
+**Fix**: both `fopen(path, "r")` call sites (the SLC/PRM-derived input,
+and the `=bf` grid input) changed to `fopen(path, "rb")`. Harmless on
+POSIX (identical behavior), fixes the corruption on Windows.
+
+Applied automatically at build time on every platform (see above) --
+safe everywhere since `"rb"` behaves exactly like `"r"` on POSIX.

--- a/gmtsar/python/c_fixes/conv.c
+++ b/gmtsar/python/c_fixes/conv.c
@@ -1,0 +1,377 @@
+/*	$Id: conv.c 109 2015-01-19 23:01:24Z sandwell $	*/
+/***************************************************************************/
+/* conv convolves a 2-D filter with an array and outputs the results       */
+/* at a sub-sampled interval.  Basically it does the same thing as         */
+/* the GIPS program ihbox but it runs a lot faster.                        */
+/*                                                                         */
+/***************************************************************************/
+
+/***************************************************************************
+ * Creator:  David T. Sandwell                                             *
+ *           (Scripps Institution of Oceanography)                         *
+ * Date   :  04/17/98                                                      *
+ ***************************************************************************/
+
+/***************************************************************************
+ * Modification history:                                                   *
+ *                                                                         *
+ * DATE					                                   *
+ * 04/17/98     Started hacking at the code                                *
+ * 06/07/98     Removed edge effects of derivative filter                  *
+ * 01/14/10     Modified to read and write grd files - RJM                 *
+ ***************************************************************************/
+
+#include "gmtsar.h"
+
+char *USAGE = "conv [GMTSAR] - 2-D image convolution\n\n"
+              "Usage: conv idec jdec filter_file input output \n"
+              "   idec           - row decimation factor \n"
+              "   jdec           - column decimation factor \n"
+              "   filter_file    - eg. filters/gauss17x5 \n"
+              "   input          - name of file to be filtered (I*2 or R*4) \n"
+              "   output         - name of filtered output file (R*4 only) \n\n"
+              "   examples:\n"
+              "   conv 4 2 filters/gauss9x5 IMG-HH-ALPSRP109430660-H1.0__A.PRM "
+              "test.grd \n"
+              "   (makes and filters amplitude file from an SLC-file) \n\n"
+              "   conv 4 2 filters/gauss5x5 infile.grd outfile.grd \n"
+              "   (filters a float file) \n ";
+
+int input_file_type, format_flag;
+
+/*-------------------------------------------------------------*/
+int determine_file_type(char *name, int *input_file_type) {
+	int n, m;
+	char tail[8];
+
+	*input_file_type = 1;
+
+	n = (int)strlen(name);
+	m = n - 3;
+	strncpy(&tail[0], &name[m], 4);
+	if (verbose)
+		fprintf(stderr, " name %s tail %s \n", name, tail);
+
+	if ((strncmp(tail, "PRM", 3) == 0) || (strncmp(tail, "prm", 3) == 0)) {
+		if (verbose)
+			fprintf(stderr, " input: PRM file\n");
+		*input_file_type = 2;
+	}
+
+	if (*input_file_type == 1)
+		if (verbose)
+			fprintf(stderr, " input: GMT binary\n");
+
+	return (EXIT_SUCCESS);
+}
+
+/*-------------------------------------------------------------*/
+FILE *read_PRM_file(char *prmfilename, char *input_file_name, struct PRM p, int *xdim, int *ydim) {
+	FILE *f_input_prm, *f_input;
+	void change_name(char *);
+
+	if (verbose)
+		fprintf(stderr, " reading PRM file %s\n", prmfilename);
+	if ((f_input_prm = fopen(prmfilename, "r")) == NULL)
+		die("Can't open input header", prmfilename);
+	null_sio_struct(&p);
+    get_sio_struct(f_input_prm, &p);
+	strcpy(input_file_name, p.SLC_file);
+	format_flag = 2;
+	if (strncmp(p.dtype, "c", 1) == 0)
+		format_flag = 3;
+	if (verbose)
+		fprintf(stderr, " reading PRM file %s\n", input_file_name);
+	if ((f_input = fopen(input_file_name, "rb")) == NULL)
+		die("Can't open input data ", input_file_name);
+	*xdim = p.num_rng_bins;
+	*ydim = p.num_valid_az * p.num_patches;
+
+	return (f_input);
+}
+
+/*-------------------------------------------------------------*/
+int read_float(float *indat, int xdim, FILE *f_input, int yarr, float *buffer, int ibuff) {
+	int i, j;
+
+	for (i = 0; i < ibuff; i++) {
+		fread(indat, sizeof(float), xdim, f_input);
+		for (j = 0; j < xdim; j++)
+			buffer[j + xdim * (i + yarr)] = indat[j];
+	}
+
+	return (EXIT_SUCCESS);
+}
+/*-------------------------------------------------------------*/
+int read_SLC_int(short *ci2, int xdim, FILE *f_input, int yarr, float *buffer, double dfact, int ibuff) {
+	int i, j;
+	double df2;
+
+	df2 = dfact * dfact;
+
+	/* read i2 complex and calculate amplitude */
+	/* use square of amplitude to match gips ihconv */
+	for (i = 0; i < ibuff; i++) {
+		fread(ci2, 2 * sizeof(short), xdim, f_input);
+		for (j = 0; j < xdim; j++)
+			buffer[j + xdim * (i + yarr)] = (float)(df2 * ci2[2 * j] * ci2[2 * j] + df2 * ci2[2 * j + 1] * ci2[2 * j + 1]);
+	}
+
+	return (EXIT_SUCCESS);
+}
+
+/*-------------------------------------------------------------*/
+int read_SLC_float(float *cf2, int xdim, FILE *f_input, int yarr, float *buffer, double dfact, int ibuff) {
+	int i, j;
+	double df2;
+
+	df2 = dfact * dfact;
+
+	/* read r4 complex and calculate amplitude */
+	/* use square of amplitude to match gips ihconv */
+	for (i = 0; i < ibuff; i++) {
+		fread(cf2, 2 * sizeof(float), xdim, f_input);
+		for (j = 0; j < xdim; j++)
+			buffer[j + xdim * (i + yarr)] = (float)(df2 * cf2[2 * j] * cf2[2 * j] + df2 * cf2[2 * j + 1] * cf2[2 * j + 1]);
+	}
+	return (EXIT_SUCCESS);
+}
+
+int main(int argc, char **argv) {
+	int idec, jdec;
+	int iout, jout;
+	int i, j, ic, jc, norm, ic0, ic1;
+	int ydim = 0, xdim = 0; /* size of input file */
+	int xarr, yarr, narr, yarr2;
+	int nbuff, ibuff, imove;
+	int iend, ylen, iread;
+	uint64_t left_node;
+	unsigned int row;
+	char input_name[128], output_name[128], prmfilename[128], *c = NULL;
+	short *cindat = NULL;
+	float *cfdat = NULL;
+	double inc[2], wesn[4], xmax = 0.0, ymax = 0.0;
+	float *filter = NULL, *buffer = NULL, *indat = NULL;
+	float filtin, filtdat, rnorm, rnormax, anormax;
+	FILE *f_filter = NULL, *f_input = NULL;
+	struct PRM p;
+	void *API = NULL;            /* GMT control structure */
+	struct GMT_GRID *Out = NULL; /* For the output grid */
+	struct GMT_GRID *In = NULL;  /* Grid structure containing ->header and ->data */
+
+	if (argc < 6)
+		die("\n", USAGE);
+
+	/* Begin: Initializing new GMT session */
+	if ((API = GMT_Create_Session(argv[0], 0U, 0U, NULL)) == NULL)
+		return EXIT_FAILURE;
+
+	ibuff = 512;
+	verbose = 0;
+
+	null_sio_struct(&p);
+	input_file_type = 1; /* default; GMT binary */
+
+	/* format_flag = 1 => float		*/
+	/* format_flag = 2 => i*2 complex	*/
+	/* format_flag = 3 => r*4 complex	*/
+	format_flag = 1;
+
+	idec = atoi(argv[1]); /* y decimation factor */
+	jdec = atoi(argv[2]); /* x decimation factor */
+
+	if (idec <= 0 || jdec <= 0)
+		die("idec and jdec should be positive integers.", "");
+
+	/* open and filter file */
+	if ((f_filter = fopen(argv[3], "r")) == NULL)
+		die("Can't open filter", "");
+
+	/* get input and output file names */
+	strcpy(input_name, argv[4]);
+	strcpy(output_name, argv[5]);
+
+	/* read input file 	*/
+	/* GMT file or PRM file ? look at suffix (grd or PRM)*/
+	determine_file_type(input_name, &input_file_type);
+
+	if (verbose)
+		fprintf(stderr, " input file type: %d \n", input_file_type);
+
+	switch (input_file_type) {
+	case 1:
+		if (verbose)
+			fprintf(stderr, " reading GMT binary\n");
+		if ((In = GMT_Read_Data(API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_GRID_HEADER_ONLY, NULL, input_name, NULL)) ==
+		    NULL)
+			die("Can't open ", input_name);
+		if ((c = strstr(input_name, "=bf")))
+			c[0] = '\0'; /* Chop off any trailing =bf flag */
+		if ((f_input = fopen(input_name, "rb")) == NULL)
+			die("Can't open ", input_name);
+		fseek(f_input, 892L, SEEK_SET); /* Skip past the header */
+		xdim = In->header->n_columns;
+		ydim = In->header->n_rows;
+		xmax = In->header->wesn[GMT_XHI];
+		ymax = In->header->wesn[GMT_YHI];
+		if (verbose)
+			fprintf(stderr, "%d %d \n", In->header->n_columns, In->header->n_rows);
+		format_flag = 1;
+		break;
+	case 2:
+		strcpy(prmfilename, input_name);
+		f_input = read_PRM_file(prmfilename, input_name, p, &xdim, &ydim);
+		if (verbose)
+			fprintf(stderr, " reading PRM file format %d\n", format_flag);
+		xmax = xdim;
+		ymax = ydim;
+		break;
+	default:
+		die("confused about input file type", "quitting");
+	}
+
+	if (verbose)
+		fprintf(stderr, " read file %s %d %d \n", input_name, xdim, ydim);
+
+	/* read size of filter and make sure dimensions are odd */
+	if (fscanf(f_filter, "%d%d", &xarr, &yarr) != 2 || xarr < 1 || yarr < 1 || (xarr & 1) == 0 || (yarr & 1) == 0)
+		die("filter incomplete", "");
+	if (ibuff < yarr)
+		die("increase dimension of ibuff", "");
+
+	/* size of output file */
+	iout = jout = 0;
+	for (ic = 0; ic < ydim; ic = ic + idec)
+		iout = iout + 1;
+	for (jc = 0; jc < xdim; jc = jc + jdec)
+		jout = jout + 1;
+	if (verbose)
+		fprintf(stderr, " original: ydim %d xdim %d new: %d %d decimation: %d %d\n", ydim, xdim, iout, jout, idec, jdec);
+	inc[GMT_X] = round(xmax / (double)jout);
+	inc[GMT_Y] = round(ymax / (double)iout);
+	jout = floor(xmax / inc[GMT_X]);
+	iout = floor(ymax / inc[GMT_Y]);
+	if (verbose)
+		fprintf(stderr, " creating GMT grid %s \n", output_name);
+	wesn[GMT_XLO] = 0.0;
+	wesn[GMT_XHI] = inc[GMT_X] * jout;
+	wesn[GMT_YLO] = 0.0;
+	wesn[GMT_YHI] = inc[GMT_Y] * iout;
+
+	if ((Out = GMT_Create_Data(API, GMT_IS_GRID, GMT_IS_SURFACE, GMT_GRID_ALL, NULL, wesn, inc, GMT_GRID_PIXEL_REG, 0, NULL)) ==
+	    NULL)
+		die("could not allocate output grid", "");
+	if (GMT_Set_Comment(API, GMT_IS_GRID, GMT_COMMENT_IS_TITLE, "conv", Out))
+		die("could not set title", "");
+
+	/* parameters for convolution buffer */
+	narr = xarr * yarr;
+	yarr2 = (int)(yarr / 2.0);
+	if (ydim < ibuff)
+		ibuff = ydim;
+	imove = ibuff - yarr;
+	nbuff = xdim * ibuff;
+
+	if ((filter = (float *)malloc(sizeof(float) * narr)) == NULL)
+		die("memory allocation", "");
+	if ((buffer = (float *)malloc(2 * sizeof(float) * nbuff)) == NULL)
+		die("memory allocation", "");
+
+	if (format_flag == 1)
+		if ((indat = (float *)malloc(4 * xdim)) == NULL)
+			die("memory allocation", "");
+	if (format_flag == 2)
+		if ((cindat = (short *)malloc(4 * xdim)) == NULL)
+			die("memory allocation", "");
+	if (format_flag == 3)
+		if ((cfdat = (float *)malloc(8 * xdim)) == NULL)
+			die("memory allocation", "");
+
+	/* read the filter and calculate normalization constants*/
+	anormax = rnormax = 0.0f;
+	for (i = 0; i < narr; i++) {
+		if (fscanf(f_filter, "%f", &filtin) == EOF)
+			die("filter incomplete", "");
+		filter[i] = filtin;
+		anormax = anormax + (float)fabs(filter[i]);
+		rnormax = rnormax + filter[i];
+	}
+
+	norm = 0.0f;
+	if (fabs(rnormax) > 0.05 * anormax)
+		norm = 1.0f;
+	ic0 = 0;
+	iend = ylen = ibuff;
+
+	if (verbose)
+		fprintf(stderr, " format_flag %d \n", format_flag);
+
+	/* read the data (512 lines) */
+	if (format_flag == 1)
+		read_float(indat, xdim, f_input, 0, buffer, ibuff);
+	if (format_flag == 2)
+		read_SLC_int(cindat, xdim, f_input, 0, buffer, DFACT, ibuff);
+	if (format_flag == 3)
+		read_SLC_float(cfdat, xdim, f_input, 0, buffer, DFACT, ibuff);
+
+	for (ic = 0, row = 0; ic < iout * idec; ic = ic + idec) {
+
+		if (ic / 2000.0 == ic / 1000)
+			if (verbose)
+				fprintf(stderr, " line %d\n", ic);
+
+		/* check buffer and shift data up if necessary */
+		if ((ic + yarr2) >= iend && (ic + yarr2) < (ydim - 1)) {
+
+			for (i = 0; i < yarr; i++)
+				for (j = 0; j < xdim; j++)
+					buffer[j + xdim * i] = buffer[j + xdim * (i + (ylen - yarr))];
+
+			iread = MIN(imove, (ydim - iend));
+			ic0 = iend - yarr;
+			iend = iend + iread;
+			ylen = iread + yarr;
+
+			/* now read in more data into end of buffer */
+			if (format_flag == 1)
+				read_float(indat, xdim, f_input, yarr, buffer, iread);
+			if (format_flag == 2)
+				read_SLC_int(cindat, xdim, f_input, yarr, buffer, DFACT, iread);
+			if (format_flag == 3)
+				read_SLC_float(cfdat, xdim, f_input, yarr, buffer, DFACT, iread);
+
+		} /* end of ic loop */
+		left_node = GMT_Get_Index(API, Out->header, row, 0);
+		jout = 0;
+		ic1 = ic - ic0;
+
+		/* now do the 2d convolution */
+		for (jc = 0; jc < floor(xmax / inc[GMT_X]) * jdec; jc = jc + jdec) {
+			conv2d(buffer, &ylen, &xdim, filter, &yarr, &xarr, &filtdat, &ic1, &jc, &rnorm);
+			/* use a zero or null value if there is not enough data in the filter */
+			Out->data[left_node + jout] = 0.0f;
+			if (norm > 0) {
+				if (fabs(rnorm) > (0.01 * rnormax))
+					Out->data[left_node + jout] = filtdat / rnorm;
+			}
+			else {
+				if (fabs(rnorm) < 0.0001 * anormax)
+					Out->data[left_node + jout] = filtdat;
+			}
+
+			jout++;
+
+		} /* end of jc loop */
+		row++;
+	} /* end of data loop */
+	fclose(f_input);
+
+	if (GMT_Write_Data(API, GMT_IS_GRID, GMT_IS_FILE, GMT_IS_SURFACE, GMT_GRID_ALL, NULL, output_name, Out)) {
+		die("Failed to write output grid", "");
+	}
+
+	if (GMT_Destroy_Session(API))
+		return EXIT_FAILURE; /* Remove the GMT machinery */
+
+	return (EXIT_SUCCESS);
+}

--- a/gmtsar/python/c_fixes/fitoffset.c
+++ b/gmtsar/python/c_fixes/fitoffset.c
@@ -1,0 +1,493 @@
+#define _GNU_SOURCE
+#include "update_PRM.h"
+#include <assert.h>
+#include <ctype.h>
+#include <errno.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+struct valuelist {
+	double value1;
+	double value2;
+	double value3;
+	double value4;
+	double value5;
+	struct valuelist *next;
+};
+
+#ifndef MAX_PATH
+#define MAX_PATH 1024
+#endif
+
+typedef struct valuelist VALUELIST;
+
+VALUELIST *vhead;
+int NPTS0;
+
+int load_freq_xcorr(char *freq_xcorr_file);
+char **str_split(char *a_str, const char a_delim);
+void replace_multi_space_with_single_space(char *str);
+int run_gmt_trend(char *file, int n_model_params, double *coefficient1, double *coefficient2, double *coefficient3);
+int run_gmt_gmtinfo(char *file, double *coefficient1, double *coefficient2, double *coefficient3, double *coefficient4);
+int file_exists(char *filename);
+
+int main(int argc, char **argv) {
+	double SNR = 20.0;
+	int rng_p = 0;
+	int azi_p = 0;
+	VALUELIST *vcurrent;
+	char s_r_xyz[MAX_PATH] = "";
+	char s_a_xyz[MAX_PATH] = "";
+	FILE *r_xyz = NULL;
+	FILE *a_xyz = NULL;
+	int n_r_xyz = -1;
+	int n_a_xyz = -1;
+	int NPTS = 0;
+	double n_coeff1_r = 0.0;
+	double n_coeff2_r = 0.0;
+	double n_coeff3_r = 0.0;
+
+	double n_coeff1_a = 0.0;
+	double n_coeff2_a = 0.0;
+	double n_coeff3_a = 0.0;
+
+	double n_range1 = 0.0;
+	double n_range2 = 0.0;
+	double n_range3 = 0.0;
+	double n_range4 = 0.0;
+
+	double rshift = 0.0;
+	double ashift = 0.0;
+
+	int int_rshift = 0;
+	int int_ashift = 0;
+	double sub_int_r = 0.0;
+	double sub_int_a = 0.0;
+	double stretch_r = 0.0;
+	double a_stretch_r = 0.0;
+	double stretch_a = 0.0;
+	double a_stretch_a = 0.0;
+
+	char tmpstring[MAX_PATH];
+
+	if (argc > 6 || argc == 1 || argv[1] == NULL || argv[2] == NULL || file_exists(argv[4]) == 0) {
+		printf("Usage: fitoffset npar_rng npar_azi xcorr.dat prmfile.PRM [SNR]\n");
+		return 1;
+	}
+
+	if (argc == 5 && atof(argv[4]) != 0.0)
+		SNR = atof(argv[4]);
+
+	rng_p = atoi(argv[1]);
+	azi_p = atoi(argv[2]);
+
+	load_freq_xcorr(argv[3]);
+
+	/* Open a temporary file for r.xyz */
+	snprintf(s_r_xyz, sizeof s_r_xyz, "%s", "/tmp/r.xyz.XXXXXX");
+	if ((n_r_xyz = mkstemp(s_r_xyz)) == -1 || (r_xyz = fdopen(n_r_xyz, "w+")) == NULL) {
+		if (n_r_xyz != -1) {
+			unlink(s_r_xyz);
+			close(n_r_xyz);
+		}
+		fprintf(stderr, "%s: %s\n", s_r_xyz, strerror(errno));
+		return (0);
+	}
+	/* Open a temporary file for a.xyz */
+	snprintf(s_a_xyz, sizeof s_a_xyz, "%s", "/tmp/a.xyz.XXXXXX");
+	if ((n_a_xyz = mkstemp(s_a_xyz)) == -1 || (a_xyz = fdopen(n_a_xyz, "w+")) == NULL) {
+		if (n_a_xyz != -1) {
+			unlink(s_a_xyz);
+			close(n_a_xyz);
+		}
+		fprintf(stderr, "%s: %s\n", s_a_xyz, strerror(errno));
+		return (0);
+	}
+
+	for (vcurrent = vhead; vcurrent; vcurrent = vcurrent->next) {
+		if (vcurrent->value5 > SNR) {
+			/* Write the values to r.xyz */
+			fprintf(r_xyz, "%.6f %.6f %.6f\n", vcurrent->value1, vcurrent->value3, vcurrent->value2);
+			/* Increment NPTS by 1 for every line written */
+			NPTS++;
+		}
+	}
+
+	for (vcurrent = vhead; vcurrent; vcurrent = vcurrent->next) {
+		if (vcurrent->value5 > SNR) {
+			/* Write the values to a.xyz */
+			fprintf(a_xyz, "%.6f %.6f %.6f\n", vcurrent->value1, vcurrent->value3, vcurrent->value4);
+		}
+	}
+
+	if (NPTS < 8) {
+		if (r_xyz)
+			fclose(r_xyz);
+
+		if (a_xyz)
+			fclose(a_xyz);
+
+		/* Remove the temporary files */
+		unlink(s_r_xyz);
+		unlink(s_a_xyz);
+
+		printf("FAILED - not enough points to estimate parameters\ntry using a "
+		       "lower SNR\nNPTS0 = %d NPTS = %d\n\n",
+		       NPTS0, NPTS);
+		return 1;
+	}
+
+	fflush(r_xyz);
+	fflush(a_xyz);
+
+	/* Close any open files */
+	if (r_xyz)
+		fclose(r_xyz);
+
+	if (a_xyz)
+		fclose(a_xyz);
+
+	/* Run gmt to get coefficients */
+	run_gmt_trend(s_r_xyz, rng_p, &n_coeff1_r, &n_coeff2_r, &n_coeff3_r);
+	run_gmt_trend(s_a_xyz, azi_p, &n_coeff1_a, &n_coeff2_a, &n_coeff3_a);
+
+	/* run gmt gmtinfo to get range and azimuth coefficients */
+	run_gmt_gmtinfo(s_r_xyz, &n_range1, &n_range2, &n_range3, &n_range4);
+
+	/* Calculate range and azimuth shifts */
+	rshift = n_coeff1_r - n_coeff2_r * (n_range2 + n_range1) / (n_range2 - n_range1) -
+	         n_coeff3_r * (n_range4 + n_range3) / (n_range4 - n_range3);
+	ashift = n_coeff1_a - n_coeff2_a * (n_range2 + n_range1) / (n_range2 - n_range1) -
+	         n_coeff3_a * (n_range4 + n_range3) / (n_range4 - n_range3);
+
+	/* Calculate range and azimuth stretches */
+	stretch_r = n_coeff2_r * 2.0 / (n_range2 - n_range1);
+	a_stretch_r = n_coeff3_r * 2.0 / (n_range4 - n_range3);
+
+	stretch_a = n_coeff2_a * 2.0 / (n_range2 - n_range1);
+	a_stretch_a = n_coeff3_a * 2.0 / (n_range4 - n_range3);
+
+	if (rshift >= 0) {
+		int_rshift = trunc(rshift);
+		sub_int_r = (rshift - (double)trunc(rshift));
+	}
+	else {
+		int_rshift = floor(rshift);
+		sub_int_r = 1 + (rshift - (double)trunc(rshift));
+	}
+
+	if (ashift >= 0) {
+		int_ashift = trunc(ashift);
+		sub_int_a = (ashift - (double)trunc(ashift));
+	}
+	else {
+		int_ashift = floor(ashift);
+		sub_int_a = 1 + (ashift - (double)trunc(ashift));
+	}
+
+#ifdef DEBUG
+	printf("s_r_xyz %s\n", s_r_xyz);
+	printf("%d lines\n", NPTS0);
+	printf("SNR = %.3f\n", SNR);
+	printf("n_coeff1_r = %.6f n_coeff2_r = %.6f n_coeff3_r = %.6f\n", n_coeff1_r, n_coeff2_r, n_coeff3_r);
+	printf("n_coeff1_r = %.6f n_coeff2_a = %.6f n_coeff3_a = %.6f\n", n_coeff1_a, n_coeff2_a, n_coeff3_a);
+	printf("n_range1 = %.0f n_range2 = %.0f n_range3 = %.0f n_range4 = %.0f\n\n", n_range1, n_range2, n_range3, n_range4);
+	printf("Range Shift = %.4f\n", rshift);
+	printf("Azimuth Shift = %.4f\n", ashift);
+
+	printf("rshift = %d\n", int_rshift);
+	printf("sub_int_r = %.4f\n", sub_int_r);
+	printf("stretch_r = %.9f\n", stretch_r);
+	printf("a_stretch_r = %.9f\n", a_stretch_r);
+
+	printf("ashift = %d\n", int_ashift);
+	printf("sub_int_a = %.4f\n", sub_int_a);
+	printf("stretch_a = %.9f\n", stretch_a);
+	printf("a_stretch_a = %.9f\n", a_stretch_a);
+#endif
+
+	/* Update rshift and associated params in PRM*/
+	sprintf(tmpstring, "%d", int_rshift);
+	update_PRM_sub(argv[4], "rshift", tmpstring);
+	sprintf(tmpstring, "%.4f", sub_int_r);
+	update_PRM_sub(argv[4], "sub_int_r", tmpstring);
+	sprintf(tmpstring, "%.9f", stretch_r);
+	update_PRM_sub(argv[4], "stretch_r", tmpstring);
+	sprintf(tmpstring, "%.9f", a_stretch_r);
+	update_PRM_sub(argv[4], "a_stretch_r", tmpstring);
+
+	/* Update ashift and associated params in PRM*/
+	sprintf(tmpstring, "%d", int_ashift);
+	update_PRM_sub(argv[4], "ashift", tmpstring);
+	sprintf(tmpstring, "%.4f", sub_int_a);
+	update_PRM_sub(argv[4], "sub_int_a", tmpstring);
+	sprintf(tmpstring, "%.9f", stretch_a);
+	update_PRM_sub(argv[4], "stretch_a", tmpstring);
+	sprintf(tmpstring, "%.9f", a_stretch_a);
+	update_PRM_sub(argv[4], "a_stretch_a", tmpstring);
+
+	/* Remove the temporary files */
+	unlink(s_r_xyz);
+	unlink(s_a_xyz);
+	printf("fitoffset:\nUpdated %s with offset parameters calculated from %s\n", argv[4], argv[3]);
+	return 0;
+}
+
+int load_freq_xcorr(char *freq_xcorr_file) {
+	FILE *fp;
+	char *line = NULL;
+	size_t len = 0;
+	ssize_t read;
+	VALUELIST *vcurrent;
+	char **tokens;
+
+	vhead = vcurrent = NULL;
+	NPTS0 = 0;
+	fp = fopen(freq_xcorr_file, "r");
+
+	if (fp == NULL)
+		return EXIT_FAILURE;
+
+	while ((read = getline(&line, &len, fp)) != -1) {
+		NPTS0++;
+		replace_multi_space_with_single_space(line);
+
+		VALUELIST *vnode = malloc(sizeof(VALUELIST));
+		tokens = str_split(trimwhitespace(line), ' ');
+
+		if (tokens) {
+			for (int i = 0; *(tokens + i); i++) {
+				switch (i) {
+				case 0:
+					vnode->value1 = atof(*(tokens + i));
+					break;
+
+				case 1:
+					vnode->value2 = atof(*(tokens + i));
+
+					break;
+
+				case 2:
+					vnode->value3 = atof(*(tokens + i));
+
+					break;
+
+				case 3:
+					vnode->value4 = atof(*(tokens + i));
+
+					break;
+
+				case 4:
+					vnode->value5 = atof(*(tokens + i));
+					break;
+				}
+
+				free(*(tokens + i));
+			}
+			free(tokens);
+		}
+
+		if (vhead == NULL) {
+			vcurrent = vhead = vnode;
+		}
+		else {
+			vcurrent = vcurrent->next = vnode;
+		}
+	}
+
+	// need free for each node
+	if (fp)
+		fclose(fp);
+	return EXIT_SUCCESS;
+}
+
+char **str_split(char *a_str, const char a_delim) {
+	char **result = 0;
+	size_t count = 0;
+	char *tmp = a_str;
+	char *last_comma = 0;
+	char delim[2];
+	delim[0] = a_delim;
+	delim[1] = 0;
+
+	/* Count how many elements will be extracted. */
+	while (*tmp) {
+		if (a_delim == *tmp) {
+			count++;
+			last_comma = tmp;
+		}
+		tmp++;
+	}
+
+	/* Add space for trailing token. */
+	count += last_comma < (a_str + strlen(a_str) - 1);
+
+	/* Add space for terminating null string so caller
+	   knows where the list of returned strings ends. */
+	count++;
+
+	result = malloc(sizeof(char *) * count);
+
+	if (result) {
+		size_t idx = 0;
+		char *token = strtok(a_str, delim);
+
+		while (token) {
+			assert(idx < count);
+			*(result + idx++) = strdup(token);
+			token = strtok(0, delim);
+		}
+		assert(idx == count - 1);
+		*(result + idx) = 0;
+	}
+
+	return result;
+}
+
+void replace_multi_space_with_single_space(char *str) {
+	char *dest = str; /* Destination to copy to */
+
+	/* While we're not at the end of the string, loop... */
+	while (*str != '\0') {
+		/* Loop while the current character is a space, AND the next
+		 * character is a space
+		 */
+		while (*str == ' ' && *(str + 1) == ' ')
+			str++; /* Just skip to next character */
+
+		/* Copy from the "source" string to the "destination" string,
+		 * while advancing to the next character in both
+		 */
+		*dest++ = *str++;
+	}
+
+	/* Make sure the string is properly terminated */
+	*dest = '\0';
+}
+
+/* Run gmt trend2d and collect the parameters */
+int run_gmt_trend(char *file, int n_model_params, double *coefficient1, double *coefficient2, double *coefficient3) {
+
+	char cmd_line[MAX_PATH] = "gmt trend2d /tmp/r.xyz.ZBbxXu -Fxyz -N\"2\"r -V >  /dev/null";
+	// char buffer[1000];
+	FILE *pipe;
+	// int len;
+	size_t glen;
+	ssize_t read;
+	// FILE *fp;
+	char *line = NULL;
+	char strfound[] = "trend2d: Model Coefficients:";
+	char **tokens;
+
+	sprintf(cmd_line, "gmt trend2d %s -Fxyz -N\"%d\"r -V  2>&1", file, n_model_params);
+
+	pipe = popen(cmd_line, "r");
+
+	if (NULL == pipe) {
+		perror("pipe");
+		return 1;
+	}
+
+	while ((read = getline(&line, &glen, pipe)) != -1) {
+		if (strncmp(strfound, line, 28) == 0) {
+			for (int i = 0; i < strlen(line); i++) {
+				if (line[i] == '\t')
+					line[i] = ' ';
+			}
+			tokens = str_split(trimwhitespace(line), ' ');
+			if (tokens) {
+				for (int i = 0; *(tokens + i); i++) {
+					switch (i) {
+					case 3:
+						*coefficient1 = atof(*(tokens + i));
+						break;
+					case 4:
+						*coefficient2 = atof(*(tokens + i));
+						break;
+					case 5:
+						*coefficient3 = atof(*(tokens + i));
+						break;
+					}
+
+					free(*(tokens + i));
+				}
+				free(tokens);
+			}
+		}
+	}
+
+	pclose(pipe);
+
+	return 0;
+}
+
+/* Run gmt gmtinfo and collect the parameters */
+int run_gmt_gmtinfo(char *file, double *coefficient1, double *coefficient2, double *coefficient3, double *coefficient4) {
+
+	char cmd_line[MAX_PATH] = "";
+	// char buffer[1000];
+	FILE *pipe;
+	// int len;
+	size_t glen;
+	ssize_t read;
+	// FILE *fp;
+	char *line = NULL;
+
+	char **tokens;
+
+	sprintf(cmd_line, "gmt gmtinfo  %s -C  2>&1", file);
+
+	pipe = popen(cmd_line, "r");
+
+	if (NULL == pipe) {
+		perror("pipe");
+		return 1;
+	}
+
+	while ((read = getline(&line, &glen, pipe)) != -1) {
+
+		for (int i = 0; i < strlen(line); i++) {
+			if (line[i] == '\t')
+				line[i] = ' ';
+		}
+		tokens = str_split(trimwhitespace(line), ' ');
+		if (tokens) {
+			for (int i = 0; *(tokens + i); i++) {
+				switch (i) {
+				case 0:
+					*coefficient1 = atof(*(tokens + i));
+					break;
+				case 1:
+					*coefficient2 = atof(*(tokens + i));
+					break;
+				case 2:
+					*coefficient3 = atof(*(tokens + i));
+					break;
+				case 3:
+					*coefficient4 = atof(*(tokens + i));
+					break;
+				}
+
+				free(*(tokens + i));
+			}
+			free(tokens);
+		}
+	}
+
+	pclose(pipe);
+
+	return 0;
+}
+
+int file_exists(char *filename) {
+	FILE *file = NULL;
+	file = fopen(filename, "r");
+	if (file != NULL) {
+		fclose(file);
+		return 1;
+	}
+	return 0;
+}

--- a/gmtsar/python/distribute_gmtsar_windows.py
+++ b/gmtsar/python/distribute_gmtsar_windows.py
@@ -1,0 +1,798 @@
+#!/usr/bin/env python3
+"""distribute_gmtsar_windows.py -- package a working native-Windows GMTSAR
+build into a single self-contained, relocatable bundle: no conda, no
+Git-for-Windows, nothing else required on the target machine.
+
+Precondition: `python gmtsar/python/install.py --system conda-windows-full` has
+already been run successfully against THIS checkout (bin/, lib/, share/
+exist and work). This script does not build gmtsar -- it only packages an
+existing build. It never modifies install.py or the conda env it built
+from; it only reads from them.
+
+Pipeline (see the do_* functions below, run in this order by main()):
+  1. do_pack_python()   -- conda-pack the env's Python runtime (numpy,
+     scipy, numba, netCDF4, matplotlib, h5py, ...) into dist/pyenv/,
+     excluding build-only content (compiler toolchain, C headers, debug
+     symbols, and unrelated junk -- see PYENV_EXCLUDE_FILTERS) that a
+     *user* of the pre-built binaries never needs. A full env is ~3.5GB;
+     the runtime-only subset is a fraction of that.
+  2. do_collect_dlls()  -- recursively resolve every non-system DLL the
+     built .exe/.dll files in bin/ depend on (objdump -p, BFS over the
+     import table) and copy them into dist/bin/. This is what lets the
+     .exe files run standalone: same DLL-search-order issue as the
+     conv.c fopen("r") bug elsewhere in this port, solved here by
+     co-locating the DLLs instead of relying on PATH.
+  3. do_copy_gmtsar()   -- copy bin/, lib/, share/ from the repo.
+  4. do_bundle_bash()   -- copy a minimal Git Bash (bash.exe +
+     msys-2.0.dll + the specific POSIX coreutils gmtsar_lib.py's
+     shell_run() commands actually invoke) into dist/git-bash/.
+     gmtsar_lib.py shells out via bash for POSIX syntax (ln -sf, rm -rf,
+     mkdir -p, &&, |) that cmd.exe can't run.
+  5. do_write_launcher() -- write a relocatable gmtsar_shell.bat, using
+     %~dp0 so the bundle works from wherever it's extracted, that runs
+     conda-unpack on first launch (conda-pack's relocation step) and
+     then sets GMTSAR/PATH and drops into a shell.
+  6. do_zip()           -- zip dist/ into the final archive.
+
+Usage:
+    python gmtsar/python/distribute_gmtsar_windows.py
+    python gmtsar/python/distribute_gmtsar_windows.py --conda-env gmtsar --output D:/dist
+    python gmtsar/python/distribute_gmtsar_windows.py --skip-pyenv   # iterate on steps 2-6 fast
+
+Does NOT (yet): run a full pipeline smoke test against the packaged
+bundle on a machine with no conda/git on PATH -- that is the real bar
+for "self-contained" (see project_rules.md on not trusting unverified
+claims) and is intentionally a separate, slower pass. --verify here only
+confirms each staged .exe loads its bundled DLLs and runs, and that the
+bundled python can import the required packages -- necessary, not
+sufficient.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import zipfile
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = (SCRIPT_DIR / ".." / "..").resolve()
+
+_LOG_PATH: Path | None = None
+
+# conda-forge packages installed for the build toolchain (m2w64-toolchain,
+# cmake, ninja -- see install.py's WINDOWS_CONDA_BOOTSTRAP_PACKAGES) that a
+# *user* running pre-built .exe files never needs. Excluding these is what
+# takes the packed env from ~3.5GB down to a fraction of that. Also strips
+# debug symbols, C/C++ headers (build-only), and doc/man content.
+# node_modules/ is NOT gmtsar's -- it's stray content (an npm install that
+# landed inside this particular env directory by accident, unrelated to
+# any conda-forge package) observed in the dev env this was built against;
+# excluded defensively since it's large (500MB+) and never touched by
+# anything gmtsar does.
+PYENV_EXCLUDE_FILTERS = [
+    ("exclude", "Library/mingw-w64/**"),
+    ("exclude", "Library/include/**"),
+    ("exclude", "Library/symbols/**"),
+    ("exclude", "Library/man/**"),
+    ("exclude", "Library/cmake/**"),
+    ("exclude", "node_modules/**"),
+    ("exclude", "conda-meta/**"),
+    ("exclude", "pkgs/**"),
+]
+
+# Git Bash coreutils gmtsar_lib.py's shell_run()-based commands actually
+# invoke, across p2p_stages.py/filter/intf/geocode/pre_proc/cleanup/etc
+# (grepped for POSIX-syntax `run("...")`/`shell_run("...")` call sites --
+# ln, rm, mkdir, cp, mv, cat, alias are used directly; the rest are
+# bash builtins or come along with coreutils' usual companions and are
+# cheap enough to include rather than risk a missing-tool failure deep
+# in a pipeline run).
+BASH_COREUTILS = [
+    "ln.exe", "rm.exe", "mkdir.exe", "cp.exe", "mv.exe", "cat.exe",
+    "ls.exe", "rmdir.exe", "touch.exe", "basename.exe", "dirname.exe",
+    "grep.exe", "sed.exe", "tr.exe", "cut.exe", "head.exe", "tail.exe",
+    "sort.exe", "uniq.exe", "wc.exe", "env.exe", "sleep.exe", "true.exe",
+    "false.exe", "printf.exe", "echo.exe", "test.exe", "[.exe",
+]
+
+
+def _utc_now() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _log(line: str) -> None:
+    print(line)
+    if _LOG_PATH is not None:
+        with open(_LOG_PATH, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+
+
+def _run(cmd: list[str], **kwargs) -> None:
+    cmd_str = " ".join(str(c) for c in cmd)
+    _log(f"[{_utc_now()}] ==> {cmd_str}")
+    t0 = time.time()
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                             text=True, bufsize=1, **kwargs)
+    for line in proc.stdout:
+        _log(line.rstrip("\n"))
+    rc = proc.wait()
+    dt = time.time() - t0
+    if rc != 0:
+        _log(f"[{_utc_now()}] FAILED after {dt:.3f}s (rc={rc}): {cmd_str}")
+        raise subprocess.CalledProcessError(rc, cmd)
+    _log(f"[{_utc_now()}] done in {dt:.3f}s (rc=0): {cmd_str}")
+
+
+# ------------------------------------------------------------ preconditions --
+
+def check_preconditions(gmtsar_bin: Path) -> None:
+    missing = [p for p in (gmtsar_bin, REPO_ROOT / "share" / "gmtsar" / "filters",
+                            REPO_ROOT / "lib")
+               if not p.exists()]
+    if missing:
+        sys.exit(
+            "ERROR: this checkout doesn't have a working native-Windows build "
+            f"yet (missing: {', '.join(str(m) for m in missing)}). Run:\n"
+            "    python gmtsar/python/install.py --system conda-windows-full\n"
+            "first -- this script only packages an existing build, it doesn't "
+            "create one.")
+    conv_exe = gmtsar_bin / "conv.exe"
+    if not conv_exe.is_file():
+        sys.exit(f"ERROR: {conv_exe} not found -- build looks incomplete.")
+
+
+def locate_conda_env(conda_env: str) -> Path:
+    import json
+    conda_base = None
+    for base in (r"D:\anaconda", os.path.expanduser("~\\.conda"),
+                 os.path.expanduser("~\\anaconda3"), os.path.expanduser("~\\miniconda3"),
+                 r"C:\ProgramData\Anaconda3"):
+        conda_bat = Path(base) / "condabin" / "conda.bat"
+        envs_root = Path(base) / "envs"
+        if (envs_root / conda_env).is_dir():
+            return envs_root / conda_env
+        if conda_bat.is_file():
+            conda_base = Path(base)
+    if conda_base is not None:
+        out = subprocess.run(["cmd", "/c", str(conda_base / "condabin" / "conda.bat"),
+                               "env", "list", "--json"],
+                              capture_output=True, text=True)
+        if out.returncode == 0:
+            for p in json.loads(out.stdout).get("envs", []):
+                if Path(p).name == conda_env:
+                    return Path(p)
+    sys.exit(f"ERROR: could not locate conda env '{conda_env}' -- pass --conda-env-path explicitly.")
+
+
+# ---------------------------------------------------------------- step 1 ----
+
+def do_pack_python(conda_env_path: Path, dist: Path, force: bool) -> Path:
+    """conda-pack the env's Python runtime into dist/pyenv/ (a directory,
+    not an archive -- do_zip() folds it into the final single zip)."""
+    pyenv_dir = dist / "pyenv"
+    if pyenv_dir.exists():
+        if not force:
+            _log(f"==> {pyenv_dir} already exists, skipping pack (--force to redo)")
+            return pyenv_dir
+        shutil.rmtree(pyenv_dir)
+
+    import conda_pack  # noqa: local import -- optional dep, see requirements note in main()
+    _log(f"==> conda-pack {conda_env_path} -> {pyenv_dir} "
+         "(excluding build-only toolchain/headers/symbols; this takes a while)")
+    conda_pack.pack(
+        prefix=str(conda_env_path),
+        output=str(pyenv_dir),
+        format="no-archive",
+        filters=PYENV_EXCLUDE_FILTERS,
+        force=force,
+        n_threads=-1,
+        verbose=True,
+    )
+    return pyenv_dir
+
+
+# ---------------------------------------------------------------- step 2 ----
+
+# Windows system DLLs are resolved by checking real presence in System32
+# (the 64-bit view -- NOT SysWOW64, whose 32-bit DLLs an x64 exe cannot
+# load; a name present ONLY there must be bundled, not skipped). Not a
+# maintained name-pattern allowlist, which is exactly the kind of list
+# that silently rots. Two deliberate exceptions:
+#  - api-ms-win-*/ext-ms-* "API set" names are VIRTUAL on Win10+: the
+#    loader resolves them via the OS ApiSetSchema, never the filesystem.
+#    Treated as system unconditionally, and never bundled (shipping the
+#    conda env's stub files alongside the exes is at best dead weight).
+#  - MSVC runtime DLLs (vcruntime*/msvcp*/concrt*) are NEVER treated as
+#    system even when present in System32: presence there just means THIS
+#    machine has some VC redist installed -- a clean target may not, and
+#    conda-built DLLs (gmt.dll etc.) hard-require them. Bundle app-locally
+#    from the conda env (which ships them, and their license permits it).
+_SYSTEM32 = Path(os.environ.get("SystemRoot", r"C:\Windows")) / "System32"
+
+
+def _is_system_dll(name: str) -> bool:
+    low = name.lower()
+    if low.startswith(("api-ms-", "ext-ms-")):
+        return True
+    if low.startswith(("vcruntime", "msvcp", "concrt")):
+        return False
+    return (_SYSTEM32 / name).is_file()
+
+
+def _dll_imports(objdump: Path, path: Path) -> list[str]:
+    out = subprocess.run([str(objdump), "-p", str(path)], capture_output=True, text=True).stdout
+    return [ln.split("DLL Name:")[1].strip() for ln in out.splitlines() if "DLL Name:" in ln]
+
+
+def _pe_forwarder_targets(path: Path) -> set[str]:
+    """DLL names referenced by this PE's export FORWARDERS -- exports whose
+    address entry points at an ASCII "TargetModule.TargetFunction" string
+    instead of code. The loader resolves these at import time exactly like
+    static imports, but NO import-table walk can see them. Real bug found
+    2026-07-23 by the isolated-PATH verify: conda-forge's libblas.dll/
+    liblapack.dll are pure forwarder shims to mkl_rt.N.dll, so gmt.dll
+    (which imports the shims) died STATUS_DLL_NOT_FOUND with every
+    import-table dependency present and loadable.
+
+    Minimal PE export-directory parse (stdlib only, no pefile dep). Any
+    malformed/unparseable file returns empty -- the import walk still
+    covers it, and _verify is the final backstop."""
+    try:
+        data = path.read_bytes()
+        pe_off = int.from_bytes(data[0x3C:0x40], "little")
+        if data[pe_off:pe_off + 4] != b"PE\0\0":
+            return set()
+        n_sections = int.from_bytes(data[pe_off + 6:pe_off + 8], "little")
+        opt_size = int.from_bytes(data[pe_off + 20:pe_off + 22], "little")
+        opt_off = pe_off + 24
+        magic = int.from_bytes(data[opt_off:opt_off + 2], "little")
+        dd_off = opt_off + (112 if magic == 0x20B else 96)  # PE32+ vs PE32
+        exp_rva = int.from_bytes(data[dd_off:dd_off + 4], "little")
+        exp_size = int.from_bytes(data[dd_off + 4:dd_off + 8], "little")
+        if not exp_rva:
+            return set()
+        sections = []
+        sec_off = opt_off + opt_size
+        for i in range(n_sections):
+            s = sec_off + 40 * i
+            va = int.from_bytes(data[s + 12:s + 16], "little")
+            raw_size = int.from_bytes(data[s + 16:s + 20], "little")
+            raw_ptr = int.from_bytes(data[s + 20:s + 24], "little")
+            virt_size = int.from_bytes(data[s + 8:s + 12], "little")
+            sections.append((va, max(raw_size, virt_size), raw_ptr))
+
+        def off(rva: int) -> int | None:
+            for va, size, raw in sections:
+                if va <= rva < va + size:
+                    return raw + (rva - va)
+            return None
+
+        e = off(exp_rva)
+        if e is None:
+            return set()
+        n_funcs = int.from_bytes(data[e + 20:e + 24], "little")
+        aof_rva = int.from_bytes(data[e + 28:e + 32], "little")
+        aof = off(aof_rva)
+        if aof is None:
+            return set()
+        targets: set[str] = set()
+        for i in range(n_funcs):
+            func_rva = int.from_bytes(data[aof + 4 * i:aof + 4 * i + 4], "little")
+            # A forwarder iff the entry points INSIDE the export directory.
+            if not (exp_rva <= func_rva < exp_rva + exp_size):
+                continue
+            so = off(func_rva)
+            if so is None:
+                continue
+            end = data.index(b"\0", so)
+            fwd = data[so:end].decode("ascii", "replace")
+            module = fwd.rsplit(".", 1)[0]  # "mkl_rt.2.dll.dgemm_" -> "mkl_rt.2.dll"
+            if not module.lower().endswith(".dll"):
+                module += ".dll"           # "NTDLL.RtlX" -> "NTDLL.dll"
+            targets.add(module)
+        return targets
+    except Exception:
+        return set()
+
+
+def do_collect_dlls(gmtsar_bin: Path, conda_env_path: Path, objdump: Path, dist_bin: Path) -> None:
+    """BFS every bin/*.exe and *.dll over BOTH dependency channels -- the
+    import table AND export forwarders (see _pe_forwarder_targets) --
+    resolving each non-system DLL against the conda env's library dirs and
+    copying into dist_bin/. Raises if anything can't be resolved -- a
+    silently-missing DLL is a bundle that works on the dev machine and
+    crashes for every real user (project_rules.md Rule 1)."""
+    search_dirs = [
+        conda_env_path / "Library" / "bin",
+        conda_env_path / "Library" / "mingw-w64" / "bin",
+        conda_env_path,
+        gmtsar_bin,
+    ]
+    start = list(gmtsar_bin.glob("*.exe")) + list(gmtsar_bin.glob("*.dll"))
+    _log(f"==> walking DLL dependencies (imports + export forwarders) "
+         f"from {len(start)} files in {gmtsar_bin}")
+    resolved: dict[str, Path] = {}
+    queue = list(start)
+    unresolved: set[str] = set()
+    while queue:
+        f = queue.pop()
+        deps = set(_dll_imports(objdump, f)) | _pe_forwarder_targets(f)
+        for dll in deps:
+            if dll.lower() in resolved or _is_system_dll(dll):
+                continue
+            hit = next((d / dll for d in search_dirs if (d / dll).is_file()), None)
+            if hit is None:
+                unresolved.add(dll)
+                continue
+            resolved[dll.lower()] = hit
+            queue.append(hit)
+
+    mkl = sorted(n for n in resolved if n.startswith("mkl_"))
+    if mkl:
+        sys.exit(
+            f"ERROR: the dependency walk pulled in MKL ({mkl}) -- this env's "
+            "libblas/liblapack shims are the MKL variant. MKL cannot be "
+            "bundled statically (mkl_rt dispatches to mkl_core/mkl_avx*/... "
+            "via runtime LoadLibrary that no static walk can see). Switch "
+            "the env to the openblas variant first:\n"
+            "    conda install -n <env> -c conda-forge libblas=*=*openblas "
+            "liblapack=*=*openblas libcblas=*=*openblas\n"
+            "(install.py's WINDOWS_CONDA_BOOTSTRAP_PACKAGES pins this for "
+            "fresh envs since v2.10.3.)")
+
+    if unresolved:
+        sys.exit(
+            "ERROR: could not resolve these DLL dependencies (bundle would be "
+            f"broken on a clean machine): {sorted(unresolved)}\n"
+            "Either they're genuinely missing from the conda env, or "
+            "_is_system_dll()/search_dirs needs updating.")
+
+    dist_bin.mkdir(parents=True, exist_ok=True)
+    total = 0
+    for name, src in sorted(resolved.items()):
+        dst = dist_bin / src.name
+        shutil.copy2(src, dst)
+        total += dst.stat().st_size
+    _log(f"==> copied {len(resolved)} DLLs ({total/1e6:.1f} MB) into {dist_bin}")
+
+
+# ---------------------------------------------------------------- step 3 ----
+
+def do_copy_gmtsar(dist: Path, force: bool) -> None:
+    """bin/, lib/, share/ -- plus the Python framework source tree at
+    gmtsar/python/{utils,bin_py}: the staged bin_py tools (phasediff_py,
+    SAT_llt2rat_py, ...) locate their `utils` package via the
+    $GMTSAR/gmtsar/python/utils fallback (Windows staging copies scripts
+    flatly into bin/, so sibling-relative lookup fails there), and with
+    GMTSAR pointing at the bundle root that tree must exist INSIDE the
+    bundle -- found by the first full-pipeline bundle smoke, 2026-07-23."""
+    py_src = REPO_ROOT / "gmtsar" / "python"
+    for sub in ("utils", "bin_py"):
+        dst = dist / "gmtsar" / "python" / sub
+        if dst.exists() and not force:
+            _log(f"==> {dst} already exists, skipping (--force to redo)")
+        else:
+            if dst.exists():
+                shutil.rmtree(dst)
+            shutil.copytree(py_src / sub, dst,
+                            ignore=shutil.ignore_patterns("__pycache__", "tests",
+                                                           "archive", "*.pyc"))
+            _log(f"==> copied {py_src / sub} -> {dst}")
+    for name in ("bin", "lib", "share"):
+        src = REPO_ROOT / name
+        dst = dist / name
+        if dst.exists() and not force:
+            _log(f"==> {dst} already exists, skipping (--force to redo)")
+            continue
+        if dst.exists():
+            shutil.rmtree(dst)
+        _log(f"==> copying {src} -> {dst}")
+        shutil.copytree(src, dst)
+
+
+# ---------------------------------------------------------------- step 4 ----
+
+def do_bundle_bash(dist: Path, objdump: Path, force: bool) -> None:
+    """Bundle a minimal REAL Git Bash into dist/git-bash/usr/bin/.
+
+    Crucial subtlety (found by the isolated-PATH verify, 2026-07-23):
+    Git for Windows' `Git\\bin\\bash.exe` -- the path gmtsar_lib's
+    _win_bash() resolves and everyone knows -- is NOT bash. It's a tiny
+    launcher stub that re-executes `..\\usr\\bin\\bash.exe`; copied
+    alone it dies with "('...\\usr\\bin\\bash.exe' not found) Need a
+    valid command-line". The real interpreter, its msys-*.dll runtime,
+    and the coreutils all live under `usr\\bin\\`, so the bundle
+    replicates exactly that layout and everything (launcher, verify,
+    GMTSAR_WIN_BASH) points at usr/bin/bash.exe directly -- no stub.
+
+    Each bundled tool's msys-*.dll dependencies are resolved via its
+    actual import table (same objdump walk as the main DLL step) rather
+    than a hardcoded 'msys-2.0.dll' guess -- sed/grep etc. pull extra
+    msys runtime DLLs (iconv, intl, pcre) a guess would miss."""
+    git_bash_dir = dist / "git-bash"
+    if git_bash_dir.exists() and not force:
+        _log(f"==> {git_bash_dir} already exists, skipping (--force to redo)")
+        return
+    if git_bash_dir.exists():
+        shutil.rmtree(git_bash_dir)
+
+    sys.path.insert(0, str(REPO_ROOT / "gmtsar" / "python" / "utils"))
+    import gmtsar_lib
+    stub_or_real = Path(gmtsar_lib._win_bash())
+    if not stub_or_real.is_file():
+        sys.exit("ERROR: no working Git Bash found on this machine -- can't bundle it. "
+                  "Install Git for Windows first.")
+    git_root = stub_or_real.parent.parent  # .../Git/bin/bash.exe -> .../Git
+    usr_bin = git_root / "usr" / "bin"
+    real_bash = usr_bin / "bash.exe"
+    if not real_bash.is_file():
+        sys.exit(f"ERROR: {real_bash} not found -- unexpected Git for Windows layout.")
+
+    dst = git_bash_dir / "usr" / "bin"
+    dst.mkdir(parents=True, exist_ok=True)
+
+    to_copy = [real_bash]
+    missing = []
+    for tool in BASH_COREUTILS:
+        src = usr_bin / tool
+        if src.is_file():
+            to_copy.append(src)
+        else:
+            missing.append(tool)
+
+    copied: set[str] = set()
+    queue = list(to_copy)
+    while queue:
+        f = queue.pop()
+        if f.name.lower() in copied:
+            continue
+        shutil.copy2(f, dst / f.name)
+        copied.add(f.name.lower())
+        for dep in _dll_imports(objdump, f):
+            if dep.lower().startswith("msys-") and dep.lower() not in copied:
+                dep_src = usr_bin / dep
+                if dep_src.is_file():
+                    queue.append(dep_src)
+    # MSYS maps /tmp to <msys-root>/tmp (= git-bash/tmp here); without it
+    # every bash start warns "could not find /tmp, please create!" and
+    # anything using mktemp breaks. Ship it empty.
+    (git_bash_dir / "tmp").mkdir(exist_ok=True)
+    if missing:
+        _log(f"WARN: coreutils not found in {usr_bin}, not bundled: {missing}")
+    n_dlls = sum(1 for c in copied if c.endswith(".dll"))
+    _log(f"==> bundled real Git Bash ({real_bash}) + "
+         f"{len(copied) - n_dlls - 1} coreutils + {n_dlls} msys DLLs into {dst}")
+
+
+# ---------------------------------------------------------------- step 5 ----
+
+LAUNCHER_TEMPLATE = r"""@echo off
+setlocal
+set "HERE=%~dp0"
+if not exist "%HERE%pyenv\.gmtsar_unpacked" (
+    echo First run: relocating the bundled Python environment...
+    call "%HERE%pyenv\Scripts\conda-unpack.exe"
+    if errorlevel 1 (
+        echo conda-unpack failed -- see above.
+        exit /b 1
+    )
+    echo done > "%HERE%pyenv\.gmtsar_unpacked"
+)
+set "GMTSAR=%HERE%."
+rem pyenv\Library\bin: the gmt.exe CLI driver (and ghostscript etc.) live
+rem there -- the pipeline shells out to `gmt ...` constantly; dist\bin only
+rem carries the DLLs the gmtsar .exes link. Found by the first full-pipeline
+rem bundle smoke ("command not found (rc=127): gmt set ...").
+set "PATH=%HERE%bin;%HERE%git-bash\usr\bin;%HERE%pyenv;%HERE%pyenv\Scripts;%HERE%pyenv\Library\bin;%PATH%"
+set "GMTSAR_WIN_BASH=%HERE%git-bash\usr\bin\bash.exe"
+set "GMT_SHAREDIR=%HERE%pyenv\Library\share\gmt"
+if "%~1"=="" (
+    echo GMTSAR environment ready (native Windows, self-contained bundle^).
+    echo Try: p2p_processing RS2 ^<master^> ^<aligned^> config.py
+    cmd /k
+) else (
+    %*
+)
+"""
+
+
+def do_write_launcher(dist: Path) -> None:
+    launcher = dist / "gmtsar_shell.bat"
+    launcher.write_text(LAUNCHER_TEMPLATE, encoding="utf-8")
+    _log(f"==> wrote {launcher}")
+
+
+# ---------------------------------------------------------------- step 5b ----
+
+def do_write_licenses(dist: Path, conda_env_path: Path) -> None:
+    """Collate third-party license attribution INTO the bundle -- required
+    before the zip can be publicly distributed (it redistributes GMT/LGPL,
+    ghostscript/AGPL, Git Bash + coreutils + MSYS2 runtime/GPLv3, GDAL,
+    openblas, the MSVC runtime, and GMTSAR itself/GPL-3). Reads license
+    metadata from the BUILD env's conda-meta (excluded from the packed
+    pyenv, so it must be captured here at build time)."""
+    import json as _json
+    notices = dist / "THIRD_PARTY_NOTICES.md"
+    rows = []
+    for f in sorted((conda_env_path / "conda-meta").glob("*.json")):
+        try:
+            d = _json.loads(f.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        rows.append((d.get("name", f.stem), d.get("version", "?"),
+                     d.get("license") or "see upstream",
+                     d.get("channel", "")))
+    lines = [
+        "# Third-party notices -- gmtsar-windows bundle",
+        "",
+        "This bundle redistributes unmodified binaries from the projects",
+        "below. Each remains under its own license; this file is the",
+        "attribution manifest.",
+        "",
+        "## GMTSAR (this project)",
+        "GPL-3.0 -- full text at `LICENSE.TXT` in this bundle. Complete",
+        "corresponding source: https://github.com/dunyuliu/gmtsar.py.docker.dev",
+        "(the git tag matching this bundle's version).",
+        "",
+        "## Git for Windows components (`git-bash/`)",
+        "bash, GNU coreutils, and the MSYS2 runtime (msys-2.0.dll) --",
+        "GPL-3.0+; license text at `git-bash/LICENSE.txt`. Source:",
+        "https://gitforwindows.org / https://www.msys2.org .",
+        "",
+        "## Microsoft Visual C++ runtime (`bin/vcruntime*.dll`, `bin/msvcp*.dll`)",
+        "Redistributed under Microsoft's Visual Studio runtime",
+        "redistribution terms (via conda-forge's vc14_runtime package).",
+        "",
+        "## NOTABLE: Ghostscript is AGPL-3.0",
+        "The bundled Python environment includes ghostscript (a GMT",
+        "dependency, used by `gmt psconvert`). AGPL obligations apply to",
+        "redistribution and to network service use built on it.",
+        "",
+        "## Verbatim license texts (`licenses/`)",
+        "GPL-3.0: `LICENSE.TXT`. GPL-2.0, LGPL-2.1, LGPL-3.0, AGPL-3.0,",
+        "MPL-1.1, MPL-2.0: `licenses/<SPDX-id>.txt`. Components under",
+        '"GPL-2.0-only" (e.g. poppler) are covered by the GPL-2.0 text',
+        "specifically -- GPL-3 is not a substitute for -only terms.",
+        "pip-installed packages additionally carry their own texts at",
+        "`pyenv/Lib/site-packages/<pkg>-<ver>.dist-info/`.",
+        "",
+        "## Notes on specific manifest entries",
+        "- `m2w64-*` (MinGW toolchain), `cmake`, `ninja`: present in the",
+        "  BUILD environment's manifest below, but their files are",
+        "  EXCLUDED from this bundle (build-only; see",
+        "  PYENV_EXCLUDE_FILTERS) -- listed for completeness.",
+        "- `postgresql` (libpq): PostgreSQL License (permissive).",
+        "- `ucrt`: Microsoft Windows SDK redistributable (ucrtbase and",
+        "  API-set forwarders), redistribution with applications",
+        "  permitted per the Windows SDK license.",
+        "- `freetype`: dual `GPL-2.0-only OR FTL`; conveyed here under",
+        "  either at the recipient's option.",
+        "",
+        "## conda-forge packages (bundled Python environment + `bin/` DLLs)",
+        "Unmodified conda-forge builds; per-package source is available at",
+        "https://anaconda.org/conda-forge/<name>.",
+        "",
+        "| package | version | license |",
+        "|---|---|---|",
+    ]
+    lines += [f"| {n} | {v} | {lic} |" for n, v, lic, _c in rows]
+
+    # pip-installed dists (requirements.txt) live only in site-packages
+    # metadata, NOT conda-meta -- a manifest built from conda-meta alone
+    # silently omits all of them (29 on the reference env; real audit gap
+    # found 2026-07-23). Enumerate via the env's own python.
+    pip_rows = []
+    env_py = conda_env_path / "python.exe"
+    if env_py.is_file():
+        dump = subprocess.run(
+            [str(env_py), "-c", (
+                "import importlib.metadata as md, json\n"
+                "out=[]\n"
+                "for d in md.distributions():\n"
+                "    n=d.metadata['Name']; lic=(d.metadata.get('License-Expression')"
+                " or d.metadata.get('License') or '')\n"
+                "    if not lic or len(lic)>60:\n"
+                "        for c in (d.metadata.get_all('Classifier') or []):\n"
+                "            if c.startswith('License ::'):"
+                " lic=c.split('::')[-1].strip(); break\n"
+                "    out.append((n, d.version, lic or 'see dist-info'))\n"
+                "print(json.dumps(out))")],
+            capture_output=True, text=True)
+        if dump.returncode == 0:
+            import json as _json2
+            conda_names = {n.lower() for n, _v, _l, _c in rows}
+            pip_rows = [r for r in _json2.loads(dump.stdout)
+                        if r[0].lower() not in conda_names]
+    if pip_rows:
+        lines += ["", "## pip-installed packages (bundled Python environment)",
+                  "License texts ship inside the bundle at",
+                  "`pyenv/Lib/site-packages/<pkg>-<ver>.dist-info/`.",
+                  "", "| package | version | license |", "|---|---|---|"]
+        lines += [f"| {n} | {v} | {lic} |" for n, v, lic in sorted(pip_rows)]
+    notices.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    repo_license = REPO_ROOT / "LICENSE.TXT"
+    if repo_license.is_file():
+        shutil.copy2(repo_license, dist / "LICENSE.TXT")
+    git_license = Path(r"C:\Program Files\Git\LICENSE.txt")
+    if git_license.is_file():
+        (dist / "git-bash").mkdir(exist_ok=True)
+        shutil.copy2(git_license, dist / "git-bash" / "LICENSE.txt")
+    # Verbatim copyleft license texts, committed at license_texts/ (fetched
+    # once from gnu.org/mozilla.org/SPDX -- no build-time network). These
+    # are REQUIRED, not decorative: poppler is GPL-2.0-only (GPL-3 text
+    # can't substitute), gmt/dcw/gshhg are LGPL-3, geos/cairo/glib are
+    # LGPL-2.1, ghostscript is AGPL-3, spatialite/freexl are MPL-1.1.
+    texts_src = SCRIPT_DIR / "license_texts"
+    dst = dist / "licenses"
+    dst.mkdir(exist_ok=True)
+    n_texts = 0
+    if texts_src.is_dir():
+        for f in sorted(texts_src.glob("*.txt")):
+            shutil.copy2(f, dst / f.name)
+            n_texts += 1
+    if n_texts == 0:
+        sys.exit(f"ERROR: no license texts found at {texts_src} -- the bundle "
+                  "must not be distributed without them (poppler/GPL-2-only, "
+                  "ghostscript/AGPL-3, gmt/LGPL-3, ...).")
+    # Plus any per-package texts conda-forge installed into the env:
+    lic_src = conda_env_path / "Library" / "share" / "licenses"
+    if lic_src.is_dir():
+        shutil.copytree(lic_src, dst / "conda-forge", dirs_exist_ok=True)
+    _log(f"==> wrote {notices.name} ({len(rows)} conda + {len(pip_rows)} pip "
+         f"packages), LICENSE.TXT, git-bash/LICENSE.txt, {n_texts} license texts")
+
+
+# ---------------------------------------------------------------- step 6 ----
+
+def do_zip(dist: Path, output: Path) -> None:
+    _log(f"==> zipping {dist} -> {output} (this takes a while for a multi-GB bundle)")
+    if output.exists():
+        output.unlink()
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+        for root, _dirs, files in os.walk(dist):
+            for fn in files:
+                fp = Path(root) / fn
+                zf.write(fp, fp.relative_to(dist.parent))
+    _log(f"==> wrote {output} ({output.stat().st_size/1e9:.2f} GB)")
+
+
+# --------------------------------------------------------------- verify -----
+
+def do_verify(dist: Path) -> None:
+    """Necessary-not-sufficient sanity pass: each staged .exe runs (proves
+    its bundled DLLs resolve) and the bundled python can import the
+    packages the framework needs. Does NOT run a real pipeline case --
+    see module docstring.
+
+    Deliberately uses an ISOLATED PATH -- Windows system dirs only, no
+    conda env, no Git for Windows, nothing from this dev machine's own
+    setup. Testing with the dev machine's PATH still attached would let a
+    genuinely-missing bundled DLL silently resolve from the conda env
+    instead, passing "verification" for a bundle that's actually broken
+    on a clean target machine -- the exact failure mode this script
+    exists to catch (project_rules.md: don't trust unverified claims)."""
+    _log("==> verify: running each bin/*.exe with an ISOLATED PATH "
+         "(no conda/git -- proves the bundle is really standalone)")
+    system_root = os.environ.get("SystemRoot", r"C:\Windows")
+    # git-bash/usr/bin is on this PATH deliberately: it mirrors what the
+    # launcher (gmtsar_shell.bat) sets up. MSYS bash does NOT implicitly
+    # put its own /usr/bin on PATH for non-login `bash -c` invocations --
+    # without this entry, every coreutil (ln, mkdir, ...) is
+    # command-not-found even though it sits right next to bash.exe
+    # (found by this verify, 2026-07-23).
+    isolated_path = os.pathsep.join([
+        str(dist / "bin"), str(dist / "git-bash" / "usr" / "bin"),
+        os.path.join(system_root, "System32"), system_root,
+    ])
+    env = {"PATH": isolated_path, "SystemRoot": system_root}
+    failures = []
+    for exe in sorted((dist / "bin").glob("*.exe")):
+        # stdin=DEVNULL: several gmtsar tools (esarp, conv's grd path, ...)
+        # read stdin when invoked bare -- with an inherited console handle
+        # they block forever, which a verify harness must not do. A closed
+        # stdin makes them hit EOF and exit immediately.
+        try:
+            r = subprocess.run([str(exe)], capture_output=True, env=env,
+                                timeout=15, cwd=str(dist / "bin"),
+                                stdin=subprocess.DEVNULL)
+            rc = r.returncode
+        except subprocess.TimeoutExpired:
+            # It RAN for 15s -- DLL resolution succeeded (a load failure is
+            # instant); it just doesn't exit without real input. That's a
+            # pass for what THIS check verifies (startability), not a hang
+            # of the harness. subprocess already killed the child.
+            _log(f"    note: {exe.name} ran past the 15s cap (waits for "
+                 "input) -- counted as started-OK, killed")
+            continue
+        # DLL-load failure is STATUS_DLL_NOT_FOUND (0xC0000135) or
+        # STATUS_INVALID_IMAGE_FORMAT (0xC000007B, 32/64 mismatch); a
+        # normal "Usage: ..." exit (whatever code) means it started fine.
+        if rc in (-1073741515, 3221225781, -1073741701, 3221225595):
+            failures.append(exe.name)
+    if failures:
+        sys.exit(f"ERROR: these .exe failed to start under an isolated PATH "
+                  f"(DLL resolution problem -- bundle is NOT self-contained): {failures}")
+    _log(f"==> all {len(list((dist/'bin').glob('*.exe')))} .exe files start cleanly "
+         "with no conda/git on PATH")
+
+    py = dist / "pyenv" / "python.exe"
+    check = subprocess.run(
+        [str(py), "-c", "import numpy, scipy, numba, netCDF4, matplotlib; print('ok')"],
+        capture_output=True, text=True, env={"PATH": isolated_path, "SystemRoot": system_root})
+    if check.returncode != 0 or "ok" not in check.stdout:
+        sys.exit(f"ERROR: bundled python failed required imports under isolated PATH:\n"
+                  f"{check.stdout}\n{check.stderr}")
+    _log("==> bundled python imports numpy/scipy/numba/netCDF4/matplotlib OK "
+         "with no conda/git on PATH")
+
+    bash = dist / "git-bash" / "usr" / "bin" / "bash.exe"
+    bash_check = subprocess.run(
+        [str(bash), "-c", "echo hello && ln --version >/dev/null && mkdir -p /tmp/x && rm -rf /tmp/x && echo OK"],
+        capture_output=True, text=True, env={"PATH": isolated_path, "SystemRoot": system_root})
+    if bash_check.returncode != 0 or "OK" not in bash_check.stdout:
+        sys.exit(f"ERROR: bundled Git Bash failed a basic POSIX-command smoke test "
+                  f"under isolated PATH:\nstdout={bash_check.stdout}\nstderr={bash_check.stderr}")
+    _log("==> bundled Git Bash runs echo/ln/mkdir/rm OK with no system Git on PATH")
+
+
+# ------------------------------------------------------------------- main ---
+
+def main() -> None:
+    global _LOG_PATH
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--conda-env", default="gmtsar")
+    p.add_argument("--output", default=str(REPO_ROOT / "dist" / "gmtsar-windows"))
+    p.add_argument("--force", action="store_true", help="redo steps even if their output already exists")
+    p.add_argument("--skip-pyenv", action="store_true", help="skip conda-pack (slow); reuse existing dist/pyenv")
+    p.add_argument("--skip-zip", action="store_true", help="build dist/ but don't zip it (faster iteration)")
+    p.add_argument("--verify", action="store_true", help="run do_verify() after packaging")
+    args = p.parse_args()
+
+    if sys.platform != "win32":
+        sys.exit("ERROR: this packages a native-Windows build; run it on Windows.")
+
+    dist = Path(args.output).resolve()
+    dist.mkdir(parents=True, exist_ok=True)
+    _LOG_PATH = dist.parent / f"distribute_{datetime.datetime.now().strftime('%Y%m%dT%H%M%S')}.log"
+    _log(f"[{_utc_now()}] distribute_gmtsar_windows.py start; dist={dist}")
+
+    gmtsar_bin = REPO_ROOT / "bin"
+    check_preconditions(gmtsar_bin)
+    conda_env_path = locate_conda_env(args.conda_env)
+    objdump = conda_env_path / "Library" / "mingw-w64" / "bin" / "objdump.exe"
+    if not objdump.is_file():
+        sys.exit(f"ERROR: {objdump} not found -- is m2w64-toolchain installed in '{args.conda_env}'?")
+
+    if not args.skip_pyenv:
+        do_pack_python(conda_env_path, dist, args.force)
+    else:
+        _log("==> --skip-pyenv: reusing existing dist/pyenv")
+
+    # Order matters: do_copy_gmtsar wipes+recreates dist/bin from the repo's
+    # bin/ (via rmtree+copytree), so it must run BEFORE do_collect_dlls adds
+    # the DLL dependencies alongside those .exe files -- the reverse order
+    # would have do_copy_gmtsar delete the DLLs do_collect_dlls just copied.
+    do_copy_gmtsar(dist, args.force)
+    do_collect_dlls(gmtsar_bin, conda_env_path, objdump, dist / "bin")
+    do_bundle_bash(dist, objdump, args.force)
+    do_write_launcher(dist)
+    do_write_licenses(dist, conda_env_path)
+
+    if args.verify:
+        do_verify(dist)
+
+    if not args.skip_zip:
+        do_zip(dist, dist.parent / f"{dist.name}.zip")
+
+    _log(f"[{_utc_now()}] distribute_gmtsar_windows.py done. Output: {dist}")
+
+
+if __name__ == "__main__":
+    main()

--- a/gmtsar/python/docs/PATHWAY_FORWARD.md
+++ b/gmtsar/python/docs/PATHWAY_FORWARD.md
@@ -1,5 +1,129 @@
 # Pathway forward — what's ported, what's not, and why
 
+## Landed 2026-07-23 (v2.10.x): native Windows — `install.py --system conda-windows-full`
+
+GMTSAR now builds and runs natively on Windows — no WSL, no
+MSYS2/Cygwin toolchain, no admin. CMake/Ninja build against a
+conda-provided MinGW-w64 toolchain (`m2w64-toolchain`); the Python
+framework and `.csh` scripts stage into `bin/` as flat copies (no
+reliable unprivileged symlink on Windows — so `--rebuild` is required
+to pick up source edits, unlike POSIX's live symlinks). Git for
+Windows is the one external prerequisite (`gmtsar_lib.py` routes all
+POSIX-syntax shell-outs through Git Bash; `GMTSAR_WIN_BASH` overrides
+the location).
+
+**Verified state (Rule 13 vocabulary): wired ON and clean-room
+proven for RS2_SLC_Hawaii only.** Two full clean-room runs 2026-07-23
+(fresh clone + fresh conda env `gmtsar_cr`, tarball cache reused per
+Rule 14): install rc=0 end-to-end including from-scratch
+`conda create` and `pip -r requirements.txt`, then `sweep.py --fast
+--cases RS2_SLC_Hawaii --topo-mode-ab` → 6/6 comparisons SUCCESS
+(SSIM ≥0.999, grd RMS ≤7e-4), matching a same-commit Linux
+py-vs-csh run's numbers. Regression guards:
+`bin_py/tests/test_windows_port.py` (one test per real bug found in
+the bring-up — cmd metacharacter parsing, missing pip, `_win_bash`
+race, WSL-stub bash, os.sep tree-name collapse, conv.c text-mode
+fopen).
+
+**Real upstream C bug found by this port**: `gmtsar/conv.c` opened
+binary SLC/`.grd=bf` files with `fopen(..., "r")` — text mode, a
+silent-corruption no-op on POSIX but catastrophic on Windows
+(correlation collapsed to ~0 over 85% of a real RS2 swath). Fix
+staged at `c_fixes/conv.c` per the v2.9.0 convention, applied at
+build time on every platform by `_apply_c_fixes()` (now called from
+`do_windows_build()` too).
+
+**Not done / honest gaps** (per Rule 13, "verified for one case" is
+not "verified"):
+- No py-vs-csh comparison possible on Windows at all — no `csh`/`tcsh`
+  interpreter exists for native Windows; `--topo-mode-ab` (py mode0 vs
+  py mode1) is the documented substitute. The C-oracle ground truth
+  can only ever come from a POSIX run.
+- Only RS2_SLC_Hawaii exercised; the other 20 cases, `bin_py/tests/`
+  as a suite on Windows, and `tests/test_install.py` coverage for
+  `conda-windows-full` (that script is POSIX-only throughout) are all
+  open.
+- `distribute_gmtsar_windows.py` (self-contained user bundle): PROVEN
+  2026-07-23 (v2.10.3). Root cause of the earlier 27/38 verify failure
+  was export FORWARDERS — conda-forge's win-64 libblas/liblapack shims
+  forward to mkl_rt.N.dll, invisible to any import-table walk; fixed by
+  walking forwarders (`_pe_forwarder_targets`, stdlib PE parse), pinning
+  the openblas BLAS variant (`WINDOWS_CONDA_BOOTSTRAP_PACKAGES`), and a
+  fail-loud MKL guard. Four more bundle-smoke-found fixes: bundle the
+  REAL `usr\bin\bash.exe` (Git's `bin\bash.exe` is a launcher stub),
+  launcher PATH gains `pyenv\Library\bin` (the `gmt.exe` CLI lives
+  there), `GMT_SHAREDIR` pinned (the gmt.dll copy has the build env's
+  share path baked in), and the `gmtsar/python/{utils,bin_py}` tree
+  bundled (the `$GMTSAR` import fallback needs it). Evidence: 3-layer
+  isolated-PATH verify passes (38/38 exes, bundled python imports,
+  bundled bash), AND a full RS2 p2p run from the bundle alone —
+  no conda, no Git for Windows in the environment — completed with
+  `phasefilt.grd` **bit-identical** (complex-rms 0.0) to the clean-room
+  sweep's mode0 reference. Remaining caveat: all runs were on the dev
+  host; a physically different bare machine hasn't executed the bundle
+  yet. v2.11.0 adds the license-collation step (`do_write_licenses`:
+  THIRD_PARTY_NOTICES.md from the env's conda-meta, GMTSAR GPL-3 text,
+  Git-for-Windows license, AGPL/ghostscript callout) and publishes the
+  zip as a GitHub release asset.
+
+## Explored 2026-07-23: full conda toolchain isolation for `install.py --system conda`
+
+Today's `--system conda` deliberately keeps the SYSTEM's own compiler
+chain (gfortran, g++, make, autoconf, csh, ghostscript) rather than
+provisioning it via conda — see `do_conda_setup`'s docstring in
+`install.py`. User asked whether full isolation (conda providing the
+compiler too, nothing system-level required) is actually possible.
+
+**Real answer: yes, confirmed by an actual clean-room build.** Fresh
+`git clone`, a genuinely new conda env built with `micromamba` (classic
+`conda`'s solver hung 28+ min unsolved on the same package set — a real,
+separate finding: this host's conda is old, 4.14.0, pre-libmamba-solver;
+switch to `micromamba`/`conda-libmamba-solver` for any future from-conda
+bootstrap) from `gfortran_linux-64`, `gxx_linux-64`, `make`, `autoconf`,
+`ghostscript`, `tcsh`, plus the existing `CONDA_FORGE_BOOTSTRAP_PACKAGES`
+(`gmt=6.4`, `gshhg-gmt`, `dcw-gmt`, `flex`, `hdf5=1.12.*`, `libtiff`,
+`liblapack`). Real binaries (`esarp`, `xcorr`, `phasefilt`, ...) built,
+linked, and ran correctly — `ldd` showed zero missing shared libraries.
+
+Two real things needed beyond just installing packages:
+
+1. **conda-forge ships no `csh` package**, only `tcsh` — Debian/Ubuntu's
+   `csh` is itself just a `tcsh` wrapper. A `csh -> tcsh` symlink inside
+   the env's `bin/` is the fix; confirmed sufficient for what GMTSAR's
+   Python framework actually needs (per project direction, a real `csh`
+   package isn't required, only that csh invocations work).
+2. **A genuine GMTSAR source bug, found here for the first time**:
+   `gmtsar/fitoffset.c` calls `strlcpy()` with no include/declaration
+   anywhere. Implicit-declaration is only a *warning* on GCC < 14 (the
+   system's Ubuntu GCC 11.4.0, which today's `--system conda` uses) but
+   a **hard error** on GCC 14+ (conda-forge's `gxx_linux-64` is 15.2.0 —
+   GCC 14 promoted implicit function declarations to an error by default
+   as part of C23 alignment). This is NOT conda-specific — it will also
+   break `--system ubuntu` on any host with GCC 14+ (Ubuntu 24.10+,
+   Fedora 40+, Arch already ship it). Fix (`strlcpy` -> `snprintf`,
+   identical behavior for the fixed short literals involved) is staged
+   at `gmtsar/python/c_fixes/fitoffset.c` — NOT applied to the real
+   `gmtsar/gmtsar/fitoffset.c` yet (outside `gmtsar/python/`, this
+   repo's "everything else stays untouched for clean upstream merges"
+   rule) — apply manually or via a proper upstream PR when ready.
+
+`install.py`'s existing `patch_config_mk()` (TIFF/HDF5/GMT path fixup +
+`-Wl,-z,muldefs` for GCC 10+'s `-fno-common` default) already handles
+the rest correctly once the env is genuinely activated — no new code
+needed there, it was just easy to miss applying by hand during manual
+clean-room testing (cost real debugging time here).
+
+**Since wired into `install.py` as a real mode**: `--system
+conda-linux-full` (v2.9.0), using real env activation and the
+target-triplet compiler names (`x86_64-conda-linux-gnu-{cc,c++,gfortran}`),
+not plain `gcc`/`g++`/`gfortran` — see `do_conda_setup`'s docstring.
+
+Also landed independently of this exploration: `install.py` now fails
+fast with a clear message if `gfortran`/`g++`/`make`/`autoconf`/`csh`/
+`ghostscript` are missing under today's `--system conda`, instead of
+surfacing as a cryptic `autoconf`/`make` error deep in the build
+(`_check_system_build_tools()`, commit `8c169eb`).
+
 ## Fixed 2026-07-13: `write_gmt_grd` broke GMT's symlink-follow semantics
 
 Found by a real full 21-case regression sweep (`ALOS_haiti` FAIL:

--- a/gmtsar/python/docs/release_notes/release_notes_v2.10.0.md
+++ b/gmtsar/python/docs/release_notes/release_notes_v2.10.0.md
@@ -1,0 +1,255 @@
+# v2.10.0 — `--system conda-windows-full`: native Windows install (no WSL, no MSYS/Cygwin toolchain)
+
+## New: `--system conda-windows-full`
+
+`install.py --system conda-windows-full` builds and runs GMTSAR natively on
+Windows — no WSL, no MSYS2/Cygwin userland, no admin rights. Bootstraps
+a conda env with the Windows-native build toolchain
+(`m2w64-toolchain`, `cmake`, `ninja`, plus `gmt`/`openblas`/`libtiff`
+per the usual `CONDA_FORGE_BOOTSTRAP_PACKAGES`), builds via CMake/Ninja
+against it (the existing `./configure && make` path is POSIX-shell/
+Makefile-only and doesn't target Windows library layouts), and stages
+the Python framework + `.csh` scripts into `bin/` exactly like the
+other `--system` modes.
+
+The one thing this mode does still depend on: Git for Windows, for a
+real POSIX shell (`gmtsar_lib.py` shells out via Git Bash for syntax —
+`ln -sf`, `rm -rf`, `mkdir -p`, `&&` — that `cmd.exe` can't run). Nearly
+universal on Windows dev/science machines already; `gmtsar/python/
+distribute_gmtsar_windows.py` (new, WIP) packages a fully self-contained
+bundle that includes a minimal Git Bash for machines that don't have it.
+
+## `gmtsar/CMakeLists.txt` / `CMakeLists.txt`: closing real gaps in the CMake build
+
+The CMake path (previously exercised only incidentally, never as a
+release target) was missing real coverage the Makefile has had for
+years:
+
+- 11 C programs built by `make` but never added to CMake's
+  `add_executable`/`install(TARGETS ...)`: `update_PRM`, `get_PRM`,
+  `nearest_grid`, `fitoffset`, `solid_tide`, `p_scatter`,
+  `split_spectrum`, `cut_slc`, `split_aperture`,
+  `phasediff_get_topo_phase`, `geocode_slc`. `update_PRM` specifically
+  is on the hot path for every pre-processing run (`pre_proc` calls it
+  directly) — its absence broke every case at the very first
+  Preprocess stage.
+- `share/gmtsar` (filter kernels, snaphu configs, virgin PRM templates)
+  was never installed by the CMake path at all — only the Makefile's
+  `install:` target populated it. Without it, `filter`'s Gaussian
+  filtering (`gauss15x5` etc.) failed outright.
+- `libgmtsar`'s object list was missing `stringutils.c`,
+  `update_PRM_sub.c`, `rng_filter.c`, `lib_strfuncs.c` — present in the
+  Makefile's `LIB_C` but never added to CMake's `add_library`, breaking
+  the link step for anything calling into them (`update_PRM`,
+  `get_PRM`, `fitoffset`).
+- WIN32-only: a `dlltool`-generated minimal import library exporting
+  just `dgelsy_` (the one LAPACK routine GMTSAR actually calls),
+  working around a real MinGW binutils bug where linking against the
+  *full* `openblas.lib` (~77,000 exported symbols) corrupts the
+  resulting DLL at runtime regardless of which function is called —
+  isolated with a minimal repro, not specific to GMTSAR's own code. A
+  `sys/mman.h` shim (`gmtsar/compat_win32/`, `mmap`/`munmap` over
+  `CreateFileMapping`) for `sbas_utils.c`/`resamp.c`/`sbas.c`, which
+  `#include <sys/mman.h>` (not provided by MinGW). A `getline()` shim
+  (same directory) for `fitoffset.c`, force-included for that one
+  target only via `target_compile_options(-include ...)` rather than
+  editing the `.c` file — mingw-w64's runtime doesn't export this
+  glibc/POSIX extension.
+
+## Real GMTSAR source bug found: `conv.c` opens binary files in text mode
+
+`gmtsar/conv.c` opens the raw complex SLC file and the `.grd=bf`
+native-binary-float file with `fopen(path, "r")` — **text mode**.
+Invisible on POSIX (`"r"`/`"rb"` are identical there), but on Windows
+text mode makes the CRT translate `\r\n` → `\n` on read and treat byte
+`0x1A` as an EOF marker, silently corrupting or truncating a binary
+stream partway through the file.
+
+Root-caused from a real, visually-obvious symptom, not a synthetic
+test: `filter`'s `conv`-based amplitude/correlation formation
+(`amp1.grd`/`amp2.grd`/`realfilt.grd`/`imagfilt.grd`) produced a
+correlation grid that was 84.8% *exactly* zero on a real RS2 pair
+(median correlation 0.0) — collapsing the geocoded, masked
+interferogram to a thin diagonal sliver of real fringes surrounded by
+blank space, instead of full-swath coverage. Confirmed as a Windows-
+only binary-mode bug, not a Python-port logic bug, two ways: (1) a
+direct synthetic repro — `conv.exe` reading a hand-written `.grd=bf`
+file with a known NaN block via `fopen(..., "r")` silently produced
+non-NaN garbage past the corruption point, clean via `"rb"`; (2) the
+*identical* Python framework code, same commit, produces a
+near-machine-precision match against the real C/csh reference on Linux
+(`corr_ll.grd` RMS 9.7e-7, `phasefilt.grd` complex-RMS 2.2e-5) — ruling
+out the algorithm itself.
+
+**Fix**: both `fopen(path, "r")` call sites → `fopen(path, "rb")`.
+Identical behavior on POSIX. Staged at `gmtsar/python/c_fixes/conv.c`
+per the `fitoffset.c` convention from v2.9.0 (real fixes to upstream
+`gmtsar/*.c` staged in `gmtsar/python/`, not edited in place, so
+`gmtsar/gmtsar/` stays a clean diff against upstream) and applied
+automatically at build time by `_apply_c_fixes()` — which this release
+also wires into `do_windows_build()` (previously only called from
+`do_build()`, so the Windows path silently skipped both this fix and
+v2.9.0's `fitoffset.c` one until now).
+
+## `gmtsar_lib.py`: two real Windows-only bugs in the Git Bash routing itself
+
+- **Race condition**: `_win_bash()` set its "already resolved" flag
+  *before* actually assigning the resolved path, memoized across the
+  whole process. `gmtsar/python/tests/case_runner.py` runs two threads
+  concurrently per case (`csh_slot`/`py_slot`, or their `topo-mode-ab`
+  equivalents) — a thread racing in during that window read
+  `_WIN_BASH_RESOLVED = True` but `_WIN_BASH` still `None`, silently
+  falling through `shell_run()`'s `shell=True` fallback into
+  `cmd.exe`. Confirmed directly: one of two concurrent `cleanup all`
+  calls failed with `cmd.exe`'s `'cleanup' is not recognized...` while
+  the other succeeded, same run. Fixed with a real `threading.Lock`.
+- **PATH format**: an earlier iteration of this release's Windows PATH
+  handling pre-converted `PATH` to POSIX/MSYS form (`/c/...`) before
+  handing it to the `bash -c` subprocess, on the theory that bash's own
+  command lookup needs a POSIX-style `PATH`. This is true for bash's
+  *own* lookups, but broke every single `.exe` bash then launched:
+  Windows' PE loader resolves DLL dependencies (`gmt.dll`,
+  `openblas.dll`, ...) via the *Windows-style* `PATH` in the process's
+  environment block, which it cannot parse in `/c/...` form — silently
+  producing `STATUS_DLL_NOT_FOUND`, surfaced by `gmtsar_lib.run()` as a
+  bare, message-free `rc=127`. Confirmed via a direct `CreateProcess`
+  repro bypassing bash entirely: POSIX-form `PATH` → `0xC0000135`;
+  Windows-form `PATH` → clean run. Fixed by never touching `PATH`'s
+  format at all — Git Bash's own MSYS runtime already handles the
+  POSIX-view-internally / Windows-view-to-children duality correctly
+  on its own; the only real bug was PATH going stale/wrong-format
+  across nested bash→python→bash hops, fixed by threading the
+  pristine Windows-style value through explicitly (`GMTSAR_WIN_PATH`)
+  rather than trusting whatever the immediate parent process's own
+  `PATH` currently held.
+
+## Windows staging: copy-not-symlink breaks sibling-file/package imports
+
+Every other `--system` mode symlinks staged files into `bin/`
+(`stage_execs`) — edits to the source tree are picked up live, and a
+script's `__file__`, resolved through the symlink, still points at its
+real location alongside its siblings. Windows has no reliable
+unprivileged symlink, so `stage_execs` copies instead (existing
+behavior, unchanged this release) — but that silently breaks every
+staged script that locates a sibling module/package relative to
+`__file__`:
+
+- `bin_py/{SAT_baseline_py,SAT_llt2rat_py,make_los_py,make_slc_s1a_py,
+  phasediff_py}`: `sys.path` insertion assumed `_HERE.parent` still
+  contained a `utils/` sibling (true when `_HERE` resolves through a
+  symlink back to `bin_py/`; false when it's a flat copy in `bin/`).
+  Now falls back to `$GMTSAR/gmtsar/python/utils` when the naive
+  relative guess doesn't exist.
+- `phasediff_py` additionally dynamically loads `_gmt_native_bf.py`
+  from its own directory (`importlib.util.spec_from_file_location`) —
+  never staged into `bin/` at all on Windows since it isn't a `bin_py`
+  entry point in its own right. `install.py` now stages it alongside
+  `phasediff_py` explicitly.
+- `utils/filter` shelled out to `gmtsar_sharedir.csh` (a POSIX-only
+  script Windows can't exec directly without going through Git Bash)
+  to resolve the share directory; now calls `gmtsar_lib.resolve_sharedir()`
+  directly, which does the identical lookup in-process.
+- `utils/intf` and `case_runner.py` called `subprocess.run(["cleanup",
+  ...])`/`["pop_config", ...])` directly — extensionless shebang
+  scripts Windows' `CreateProcess` cannot exec (it only auto-appends
+  `.exe` to a bare name, and there is no `cleanup.exe`). Routed through
+  `gmtsar_lib.shell_run()` (Windows: `bash -c`) instead.
+
+## `gmtsar/python/tests/{sweep,case_runner,cases}.py`: three real, platform-agnostic bugs found via Windows testing
+
+None of these are Windows-specific bugs — they were latent on every
+platform, just never triggered on POSIX:
+
+- `sweep.py` and `case_runner.py` each hardcoded `":"` instead of
+  `os.pathsep` when building a `PATH` value. Harmless on POSIX
+  (`os.pathsep == ":"` there), silently produces a malformed `PATH` on
+  Windows.
+- `cases.py` built `cshRefRoot`/`pythonRunRoot`/etc. via
+  `workAbsoluteDir + "ref_test/"` — a literal forward slash appended
+  after a path already using `os.sep`. On Windows this leaves a mixed-
+  separator path whose trailing character is `/`, not `os.sep`; a
+  downstream `.rstrip(os.sep)` (used to derive the tree's directory
+  *name* for building the per-case output path) then does nothing,
+  `os.path.basename()` of a separator-terminated path returns `""`,
+  and both the "csh"/mode-0 and "python"/mode-1 trees for
+  `--topo-mode-ab` silently collapsed into the *same* directory —
+  both threads writing the same case concurrently, corrupting each
+  other's output, while `case_runner.py` still reported success.
+  Fixed by using `os.sep` consistently.
+- `case_runner.py`'s `_run_recipe()` invoked the recipe via a bare
+  `["bash", ...]`, trusting `PATH` order to find Git Bash. Windows 10+
+  ships a `System32\bash.exe` stub that launches WSL — if it resolves
+  first (a real, not hypothetical, `PATH`-ordering outcome), the
+  entire recipe run silently no-ops against a WSL "no installed
+  distributions" prompt instead of Git Bash, while `case_runner.py`
+  still reports success. `gmtsar_lib._win_bash()` already guards
+  against exactly this for every other bash invocation in the
+  framework (checks real file presence, rejects anything resolving
+  under `system32`); `_run_recipe()` now uses the same resolution
+  instead of a bare name.
+
+## `gmtsar/python/distribute_gmtsar_windows.py` (new, WIP)
+
+Packages a working `--system conda-windows-full` build into a self-
+contained, relocatable bundle — no conda, no Git for Windows required
+on the target machine:
+
+- `conda-pack`s the env's Python runtime (numpy/scipy/numba/netCDF4/
+  matplotlib/h5py/...), excluding build-only content a *user* of the
+  pre-built binaries never needs (`m2w64-toolchain`, headers, debug
+  symbols) — full env ~3.5GB, runtime-only subset a fraction of that.
+- Recursively resolves every non-system DLL the built `.exe`/`.dll`
+  files depend on (`objdump -p`, BFS over the PE import table;
+  "system" determined by real presence in `System32`/`SysWOW64`, not a
+  maintained name-pattern list) and copies them alongside the `.exe`
+  files — this is what makes the `.exe`s runnable without the conda
+  env on `PATH`, the same DLL-resolution issue as this release's
+  `conv.c` fix, solved here by co-location instead of by `PATH`.
+- Bundles a minimal Git Bash (`bash.exe`, `msys-2.0.dll`, the specific
+  coreutils the framework's `shell_run()` calls actually invoke).
+- `--verify` runs every staged `.exe` and the bundled `python` under a
+  deliberately **isolated** `PATH` (Windows system dirs + the bundle
+  only — no conda, no Git) to prove the bundle is genuinely self-
+  contained rather than passing only because the dev machine's own
+  toolchain is still on `PATH`. Caught a real gap in an earlier version
+  of this check: a naive `PATH.prepend()` verify passed even with 27 of
+  38 `.exe` files unable to start standalone.
+
+Not yet done: a full pipeline (RS2 case) run against the packaged,
+zipped bundle on a machine with nothing else installed — the real bar
+for "self-contained," intentionally left as a follow-up given this
+release's scope.
+
+## Release-boundary verification (this release)
+
+`install.py --system conda-windows-full` from a **fully clean slate**
+(`bin/`, `lib/`, `share/`, `build-win/` all wiped, not just
+`--rebuild`): 159/159 CMake/Ninja build steps, 0 errors, all 41 `.exe`
+files + `share/gmtsar` data + Python/`.csh` staging installed
+correctly.
+
+`sweep.py --topo-mode-ab` (no `csh`/`tcsh` interpreter exists on
+Windows at all, so this release's verification substitutes a
+`topo_interp_mode` 0-vs-1 comparison for the normal py-vs-csh one —
+see `cases.py`'s existing `TOPO_MODE_AB` machinery) against that clean
+build: `RS2_SLC_Hawaii` **6/6 comparisons SUCCESS** — SSIM ≥0.999 on
+all three images, grid RMS ≤0.0007 — matching, to within normal
+floating-point variation, a real py-vs-csh run's numbers from the same
+commit on Linux (`corr_ll.grd` RMS 9.7e-7 vs this release's 4.1e-4;
+both far inside the 0.01 threshold).
+
+Not yet done, tracked as real follow-ups rather than silently out of
+scope: a true py-vs-csh comparison on Windows (blocked on no `csh`/
+`tcsh` for Windows existing at all — `--topo-mode-ab` is a real but
+imperfect substitute); the full 21-case sweep (`--full`) on Windows,
+run so far only for the fast-tier `RS2_SLC_Hawaii` case; `bin_py/
+tests/` on Windows; `distribute_gmtsar_windows.py`'s packaged-bundle
+verification beyond the isolated-`PATH` `.exe`/`python`/bash smoke
+checks described above.
+
+## Commits
+
+`v2.9.0`..`v2.10.0`: the `conda-windows-full` work (previously developed
+against a shallow clone of upstream `gmtsar/gmtsar` at the commit
+matching this fork's own `v2.8.0`, rebased onto `v2.8.0` directly) plus
+this release's merge of `v2.9.0`'s `conda-linux-full` work.

--- a/gmtsar/python/docs/release_notes/release_notes_v2.10.2.md
+++ b/gmtsar/python/docs/release_notes/release_notes_v2.10.2.md
@@ -1,0 +1,86 @@
+# v2.10.2 — clean-room hardening for `--system conda-windows-full` + Rule-8 regression guards
+
+Scope: `v2.10.1..v2.10.2`. Two real bugs found by the first genuinely
+clean-room Windows run (fresh clone AND fresh conda env — v2.10.0's own
+verification had reused a pre-existing env, masking both), plus the
+regression tests and ledger updates Rules 8/13 required before this tag.
+
+## Real bug: fresh-env `conda create` failed in milliseconds (cmd metacharacters)
+
+`_windows_conda_cmd()` routed conda through `cmd /c conda.bat`. cmd
+PARSES the command line, so the package spec `libtiff>=4.5,<5` was read
+as redirection operators (stdin from a file named `5`) — "The system
+cannot find the file specified" in 0.026s. Unfixable by quoting from a
+subprocess argv list (`list2cmdline` escapes embedded quotes as `\"`,
+which survive the `.bat`'s `%*` forwarding as literal quote characters
+in conda's argv — verified, not assumed).
+
+**Fix** (`7dd6880`): prefer `Scripts\conda.exe` — a real PE executable,
+no cmd, no metacharacter parsing. Tested standalone-working on conda
+26.5.3 (`create`, `env list --json`), disproving the earlier docstring
+claim that it "only works once the env is active". The `.bat`+cmd route
+survives only as a fallback for installs with no `Scripts\conda.exe`,
+and now fails loudly on metacharacter args instead of letting cmd
+misparse them.
+
+## Real bug: `pip` missing from `WINDOWS_CONDA_BOOTSTRAP_PACKAGES`
+
+Identical bug class to the one v2.9.0 fixed in
+`CONDA_FORGE_BOOTSTRAP_PACKAGES`: python arrives transitively
+(gmt → gdal → python bindings) but pip is not guaranteed to, and
+`do_python_deps` runs `python.exe -m pip install -r requirements.txt`.
+Fixed preemptively (`1be3bce`) citing the v2.9.0 precedent, then
+confirmed exercised for real: the fresh `gmtsar_cr` env's pip step ran
+clean (204.8s, rc=0).
+
+## Clean-room verification (Rules 14/15, the real thing this time)
+
+Fresh folder + fresh clone (`D:\gmtsar-cleanroom2`, HEAD `7dd6880`,
+clean tree) + genuinely new conda env (`gmtsar_cr`, never existed);
+only the RS2 tarball cache reused, per Rule 14. Results:
+
+- `install.py --system conda-windows-full --conda-env gmtsar_cr`:
+  from-scratch `conda create` rc=0 in 196.9s via `Scripts\conda.exe`
+  with the metachar spec intact; pip rc=0; CMake/Ninja build → 38
+  exes; both `c_fixes` (conv.c "rb", fitoffset.c strlcpy) auto-applied.
+  (Caveat, stated per Rule 4: one launch was killed mid-CMake-configure
+  after env creation had succeeded; the relaunch resumed idempotently.
+  Every stage has fresh rc=0 evidence in `install_logs/`.)
+- `sweep.py --fast --cases RS2_SLC_Hawaii --topo-mode-ab`: **6/6
+  comparisons SUCCESS** (compare.py's own thresholds) — SSIM ≥0.999
+  ×3, `corr_ll.grd` RMS 4.1e-4, `filtcorr.grd` 6.6e-4, `phasefilt.grd`
+  complex-RMS 0.0109. mode0 405s / mode1 380s (1.07×). Visual
+  comparison generated via `tools/py_vs_csh_figure.py` (AB trees
+  bridged read-only via directory junctions): full-swath fringes both
+  sides, indistinguishable by eye, matching the same-commit Linux
+  py-vs-csh reference.
+
+## Rule-8 debt paid: `bin_py/tests/test_windows_port.py` (NEW, 15 guards)
+
+One regression test per real bug from the v2.10.x bring-up: cmd
+metacharacter handling + conda.exe preference + `.bat`-fallback
+fail-loud; pip in the Windows bootstrap list; `_apply_c_fixes` wired
+into `do_windows_build`; conv.c staged/wired/binary-mode (all three
+layers); `_win_bash` env override, System32-WSL-stub rejection, and a
+16-thread no-caller-sees-None race guard; `resolve_sharedir`
+forward-slash contract; `case_runner` PATH via `os.pathsep`; `cases.py`
+tree-name derivation under both `TOPO_MODE_AB` settings (the
+directory-collapse bug); `_run_recipe` resolving bash via `_win_bash`.
+All static/mock/tiny-fixture — they run and pass on POSIX too.
+
+Plus one fix to a pre-existing test: `test_pytest_in_requirements_txt`
+read `requirements.txt` with the locale codepage (GBK on this host) and
+crashed on the file's UTF-8 content — encoding now pinned. 27/27 pass
+on the Windows dev host.
+
+## Docs (Rule 13 debt paid)
+
+- `PATHWAY_FORWARD.md`: new top entry for the Windows port — wired-ON
+  state, clean-room evidence, the conv.c upstream bug, and the honest
+  gaps (no csh on Windows ever; only RS2 exercised; `distribute_
+  gmtsar_windows.py` `--verify` currently FAILING at 27/38 exes and
+  must not ship until it passes on a bare machine).
+- `README.md`: the Windows install command is `python`, not `python3`
+  (an Anaconda Prompt has no `python3` alias — the shim only exists
+  inside the env AFTER install; bit the clean-room walkthrough for
+  real).

--- a/gmtsar/python/docs/release_notes/release_notes_v2.10.3.md
+++ b/gmtsar/python/docs/release_notes/release_notes_v2.10.3.md
@@ -1,0 +1,92 @@
+# v2.10.3 — `distribute_gmtsar_windows.py` proven: bundle-only RS2 run, bit-identical
+
+Scope: `v2.10.2..v2.10.3`. Closes the one do-not-ship item v2.10.2's
+ledger flagged: the self-contained Windows bundle's isolated-PATH
+verify failing 27/38 exes. Root-caused, fixed through five real bugs,
+and proven by the strongest test available: a full RS2 pipeline run
+using **only the bundle** — no conda, no Git for Windows anywhere in
+the process environment — producing `phasefilt.grd` **bit-identical**
+(complex-rms 0.000e+00) to the clean-room sweep's mode0 reference.
+
+## Root cause of the 27/38 failure: export forwarders (MKL shims)
+
+conda-forge's win-64 `libblas.dll`/`liblapack.dll` default to the MKL
+variant — pure forwarder shims whose EXPORTS forward to `mkl_rt.N.dll`.
+The loader resolves forwarders at import time exactly like static
+imports, but they live in the export table where no import walk sees
+them, so MKL was never bundled and `gmt.dll` (which imports the shims)
+died STATUS_DLL_NOT_FOUND with every import-table dependency present.
+Diagnosed by strict elimination: static import closure complete against
+System32, every import loadable individually by bare name,
+`DONT_RESOLVE_DLL_REFERENCES` loads clean — then the shims' forwarder
+strings named `mkl_rt` directly.
+
+Fixes (each with a regression guard in `test_windows_port.py`):
+- `_pe_forwarder_targets()` — minimal stdlib PE export-directory parse;
+  the dependency walk now BFSes imports + forwarders. (Test fixture: a
+  real one — `kernel32.dll`'s famous forwards to ntdll.)
+- `WINDOWS_CONDA_BOOTSTRAP_PACKAGES` pins `libblas/liblapack/libcblas
+  =*=*openblas` — co-installing openblas does NOT flip conda-forge's
+  default MKL shims (confirmed on a genuinely fresh env), and MKL can't
+  be bundled anyway (mkl_rt dispatches to mkl_core/mkl_avx* via runtime
+  LoadLibrary no static walk can see). The walk also fail-louds with
+  that guidance if MKL ever enters the closure.
+- `_is_system_dll()` policy: api-set names are virtual on Win10+ (never
+  bundle the stub files); `vcruntime*/msvcp*/concrt*` are NEVER system
+  (System32 presence only proves the DEV machine has a VC redist);
+  SysWOW64 dropped (32-bit DLLs can't satisfy x64 exes).
+
+## Four more real bugs, found by the bundle smoke itself
+
+1. Git for Windows' `Git\bin\bash.exe` is a **launcher stub** that
+   re-executes `..\usr\bin\bash.exe` — bundled alone it dies with
+   "Need a valid command-line". The bundle now replicates the real
+   `usr/bin` layout (real bash + coreutils + each tool's `msys-*.dll`
+   deps resolved via its actual import table), ships `git-bash/tmp`
+   (MSYS `/tmp`), and everything points at `usr/bin/bash.exe`.
+2. MSYS bash does NOT implicitly put its own `/usr/bin` on PATH for
+   non-login `bash -c` — the launcher provides it; the verify now
+   mirrors that instead of false-failing with `ln: command not found`.
+3. The `gmt.exe` CLI driver (and ghostscript) live inside the packed
+   pyenv's `Library\bin` — the pipeline shells out to `gmt ...`
+   constantly and died rc=127 until the launcher PATH gained it.
+   Likewise `GMT_SHAREDIR` is pinned to the bundle's share (the
+   `gmt.dll` copy in `dist\bin` has the BUILD env's absolute share
+   path baked in — invisible on the dev machine, broken elsewhere).
+4. The staged `bin_py` tools resolve their `utils` package via the
+   `$GMTSAR/gmtsar/python/utils` fallback — the bundle now carries
+   `gmtsar/python/{utils,bin_py}` so that tree exists at the bundle's
+   GMTSAR root.
+
+Plus a verify-harness fix: exes that read stdin (`esarp` etc.) blocked
+forever on an inherited console handle — stdin is now closed (EOF-exit)
+and a genuine 15s timeout counts as started-OK (DLL failures are
+instant), instead of crashing the whole verify. `0xC000007B` (32/64
+mismatch) is caught alongside `0xC0000135`.
+
+## Verification record
+
+- 3-layer isolated-PATH verify (bundle + System32 only): **38/38 exes
+  start, bundled python imports numpy/scipy/numba/netCDF4/matplotlib,
+  bundled bash runs echo/ln/mkdir/rm** — all PASS.
+- Full-pipeline bundle smoke: RS2_SLC_Hawaii `p2p_processing` end-to-end
+  under a scrubbed environment (PATH = bundle dirs + System32 only,
+  GMTSAR/GMTSAR_WIN_BASH/GMT_SHAREDIR pointing into the bundle):
+  `P2P 7: FINISHED`, zero rc=127, zero tracebacks, `corr.grd` mean
+  0.4126 / zero-frac 0.000, and `phasefilt.grd` complex-rms
+  **0.000e+00** vs the v2.10.2 clean-room sweep's mode0 reference.
+- Honest caveats: all evidence is from the dev host (a physically
+  different bare machine hasn't executed the bundle); the final `.zip`
+  is produced on demand (run without `--skip-zip`); LICENSE/attribution
+  collation for the bundled third-party binaries is still a TODO before
+  public distribution.
+
+## Tests
+
+8 new guards appended to `bin_py/tests/test_windows_port.py` (35 total
+across the two install/Windows suites, all passing on the Windows dev
+host): openblas variant pins, `_is_system_dll` policy, forwarder parser
+on real kernel32 forwards + non-PE tolerance, forwarder-walk + MKL
+guard presence, launcher-template contract (pyenv\Library\bin,
+usr\bin\bash.exe, GMT_SHAREDIR), framework-tree bundling, and the
+stdin/timeout verify-harness behavior.

--- a/gmtsar/python/docs/release_notes/release_notes_v2.11.0.md
+++ b/gmtsar/python/docs/release_notes/release_notes_v2.11.0.md
@@ -1,0 +1,39 @@
+# v2.11.0 — first distributable Windows bundle: license attribution + published zip
+
+Scope: `v2.10.3..v2.11.0`. Small in code, significant in what it
+unlocks: v2.10.3 proved the self-contained bundle works (bundle-only
+RS2 run, bit-identical output) but flagged public distribution as
+blocked on third-party license collation. This release closes that and
+publishes the bundle as a GitHub release asset.
+
+## `do_write_licenses()` (new distribute step)
+
+The bundle redistributes GMT (LGPL-3), GDAL, openblas, **ghostscript
+(AGPL-3.0 — called out prominently)**, Git Bash + GNU coreutils + the
+MSYS2 runtime (GPL-3.0+), the MSVC runtime, and GMTSAR itself (GPL-3).
+The new step writes, into the bundle:
+
+- `THIRD_PARTY_NOTICES.md` — attribution manifest with a per-package
+  name/version/license table generated from the BUILD env's
+  `conda-meta` (excluded from the packed pyenv, so captured at build
+  time), plus source-availability pointers (this repo's tag for GMTSAR;
+  gitforwindows.org/msys2.org; anaconda.org/conda-forge).
+- `LICENSE.TXT` — GMTSAR's GPL-3 text at the bundle root.
+- `git-bash/LICENSE.txt` — Git for Windows' license file.
+- `licenses/` — per-package license texts where conda-forge installed
+  them (`Library/share/licenses`).
+
+Guarded by a new regression test (36 total across the Windows suites).
+
+## Published artifact
+
+`gmtsar-windows-<version>.zip` attached to this release on the fork:
+unzip anywhere, run `gmtsar_shell.bat` (first run relocates the
+bundled Python env via conda-unpack), and `p2p_processing` is on PATH
+with no conda, no Git for Windows, no admin rights required.
+
+Honest caveats carried forward from v2.10.3: verified on the dev host
+(isolated-PATH 3-layer verify + a full bundle-only RS2 run,
+`phasefilt.grd` complex-rms 0.000e+00 vs reference); a physically
+different bare machine has not executed the bundle yet — first-report
+feedback welcome.

--- a/gmtsar/python/docs/release_notes/release_notes_v2.12.0.md
+++ b/gmtsar/python/docs/release_notes/release_notes_v2.12.0.md
@@ -1,0 +1,96 @@
+# v2.12.0 — merge with native Windows work; `--conda-env current`; numpy≥2
+
+Scope: `v2.9.0..v2.12.0`. Two independent lines of work developed in
+parallel (this session's Linux/conda-env work on top of `v2.9.0`, and a
+separate session's native Windows port up through `v2.11.1`) merged
+here — a real, conflicted merge (one hunk in `install.py`), not a
+fast-forward. Both lines' real clean-room verification carried forward;
+see `docs/release_notes/release_notes_v2.10.0.md` through
+`release_notes_v2.11.0.md` for the Windows work's own findings
+(native `--system conda-windows-full`, `distribute_gmtsar_windows.py`,
+a real `conv.c` binary/text-mode bug on Windows, license attribution).
+
+## New: `--conda-env current`
+
+Real feedback from an external collaborator (jldz9, InSARHub
+maintainer, testing this repo's `GMTSAR_S1` PR) who wanted to install
+directly into an already-active conda env instead of always getting a
+separate `gmtsar`-named one — a real pain point when trying to share
+one env's dependency pins across two adjacent projects.
+`--conda-env current` resolves to the active env via
+`$CONDA_DEFAULT_ENV`/`$CONDA_PREFIX`. `locate_conda_env()` gained a
+`known_prefix` param used as-is instead of re-deriving the path by
+searching the fixed `CONDA_SEARCH_BASES` list by name — the active env
+could legitimately live under a non-standard root a name-search would
+miss. Verified end-to-end on this repo's own real dev env: activated
+`gmtsar`, ran `--conda-env current --rebuild`, confirmed it targeted
+that exact env (not creating a new one), full build succeeded,
+`p2p_processing`/`gmt` both work afterward. Not yet wired into
+`--system conda-windows-full` (a different code path entirely, doesn't
+share `locate_conda_env()` — real follow-up, not done here).
+
+## `requirements.txt`: `numpy<2` → `numpy>=2`, `numba>=0.56` → `>=0.60`
+
+Same collaborator asked whether the long-standing, completely
+undocumented `numpy<2` pin (every other pin in this file has a stated
+reason; this one never did) could be lifted, since his own project
+wants `numpy>=2` too. Tested for real rather than assumed safe: a
+genuine clean-room env with `numpy>=2` requested, the full
+`bin_py/tests/` suite run against it — **562 passed / 59 skipped / 0
+failed**, including the real C-vs-Python xcorr parity test (the
+bit-exact one this project's whole discipline is built around) against
+real data, bit/float-identical to the `numpy<2` baseline. Both Cython
+extensions (`build_surface_kernel.py`, `snaphu_py`'s build script)
+rebuild cleanly against numpy2 headers. `numba` floor also raised
+`>=0.56` → `>=0.60`: `numba<0.60`'s own PyPI metadata caps `numpy` well
+below 2.0 (`0.56.4`: `numpy<1.24`; `0.59.x`: `numpy<1.27`) — doesn't
+bite today since nothing else forces an old numba, but a real risk in
+an offline/locked install.
+
+## Merge notes
+
+- `install.py`'s conflict: both branches added an `elif` arm for a new
+  `--system` mode at the same location (`conda-linux-full` here,
+  `conda-windows-full` on the Windows line) — resolved by keeping both,
+  `known_prefix` threaded through the Linux full-isolation path only
+  (Windows doesn't share that machinery).
+- Everything else (README, CLAUDE.md, `PATHWAY_FORWARD.md`,
+  `c_fixes/`, `test_install_config.py`, `requirements.txt`) merged
+  cleanly with no conflicts, correctly combining both sides' real
+  content — verified directly post-merge, not assumed.
+
+## Release-boundary verification (this release)
+
+Two independent full `tests/test_install.py --system conda --full`
+clean-room runs this session, ~3h each: one at `v2.9.0` (pre-merge,
+this session's own changes only), one at this merge commit (post-merge,
+combining both lines of work). Both produced **the identical real
+result**:
+
+- `install.py --system conda`: **PASS**.
+- `gmtsar_sharedir.csh`: **PASS**.
+- `bin_py/tests/`: PASS post-merge (583 passed/60 skipped/0 failed) —
+  the pre-merge run's one failure was a real, separately-confirmed-and-
+  fixed test-isolation gap in this session's own `micromamba`-preference
+  change (see `v2.9.0`'s notes), not present in this merge's own run.
+- `sweep.py --full` (21 real py-vs-csh cases): **152/161 comparisons
+  SUCCESS**, byte-for-byte identical failure set both runs:
+  - `ALOS_haiti`: `los_ll.grd` — the accepted snaphu cycle-slip flake
+    documented since `v2.8.0`.
+  - `S1_Ridgecrest_EQ`: 8 failures, all `F1`/`F2`/`F3`/`H_res`
+    intf-level files. Root-caused directly (both runs): the cached csh
+    reference for this case is missing its `F1`/`F2`/`F3` directories
+    entirely, has no `.oracle_built` sentinel, and the sweep itself
+    flags it live (`WARN: oracle has no sentinel ... grandfathered as
+    valid`) — a stale/incomplete cached csh oracle, confirmed
+    pre-existing and stable across two independent runs regardless of
+    the code changes in between. Needs a real oracle rebuild to
+    resolve; tracked as a follow-up, not done this release (real,
+    multi-hour csh processing time beyond this release's scope).
+
+## Commits
+
+`0d49b8b` (`v2.9.0`) `..2f7566f` — this session's 3 commits
+(`--conda-env current`, `numpy`/`numba`) plus a real merge with the
+Windows line's 26 commits (`0d49b8b..41d9c85`, `v2.9.0` through
+`v2.11.1`).

--- a/gmtsar/python/docs/release_notes/release_notes_v2.9.0.md
+++ b/gmtsar/python/docs/release_notes/release_notes_v2.9.0.md
@@ -1,0 +1,173 @@
+# v2.9.0 — `--system conda-full`: real full conda-toolchain isolation for install.py
+
+## New: `--system conda-full`
+
+`install.py --system conda-full` provisions the compiler/build-tool
+chain via conda too (`gfortran_linux-64`, `gxx_linux-64`, `make`,
+`autoconf`, `ghostscript`, `tcsh`), not just GMT/HDF5/TIFF/LAPACK —
+genuinely no system packages required beyond a bare conda/miniconda
+install. Plain `--system conda` still deliberately uses the system's
+own compiler (see `do_conda_setup`'s docstring for why activation was
+previously avoided); `conda-full` is the new, real opt-in for full
+isolation.
+
+Confirmed feasible and correct via multiple real clean-room builds this
+session (fresh `git clone` + fresh conda env each time, no reuse) —
+not a design-only claim. `do_conda_setup(full_isolation=True)` resolves
+conda-forge's target-triplet-prefixed compiler binaries
+(`x86_64-conda-linux-gnu-{gcc,g++,gfortran}` — conda-forge's compiler
+packages don't install plain-named `gcc`/`g++`/`gfortran`, only these,
+meant to be picked up via env activation) and sets `CC`/`CXX`/`F77`
+explicitly to them, still only in the subprocess-only `extra_env` dict
+this script has always used — plain `--system conda`'s "never mutate
+this process's own environment" discipline is unchanged.
+`_check_conda_full_isolation_tools()` verifies a reused pre-existing
+env actually has the full tool set, and creates a `csh -> tcsh` symlink
+(no plain `csh` package exists on conda-forge — confirmed by search;
+only `tcsh`, which Debian/Ubuntu's own `csh` package itself just wraps).
+
+## Real GMTSAR source bug found: `fitoffset.c`'s `strlcpy` on GCC 14+
+
+`gmtsar/fitoffset.c` calls `strlcpy()` with no declaration/include
+anywhere. Implicit-declaration is only a *warning* on GCC < 14 (e.g.
+the system compiler `--system conda` uses today), a **hard compile
+error** on GCC 14+ (conda-forge's `gxx_linux-64` package is 15.2.0 —
+GCC 14 promoted implicit function declarations to an error by default,
+part of C23 alignment). Confirmed directly: identical source, no
+`-Werror` passed, GCC 11.4.0 → warning + successful link; GCC 15.2.0 →
+hard error. **Not conda-full-specific** — will also eventually break
+`--system ubuntu` on any host shipping GCC 14+ (Ubuntu 24.10+, Fedora
+40+, Arch already do).
+
+Fix (`strlcpy` → `snprintf`, identical behavior for the fixed short
+literals involved) is staged at `gmtsar/python/c_fixes/fitoffset.c` and
+applied as a **build-time patch for every `--system` mode**
+(`_apply_c_fixes()`, called from `do_build()`) — NOT committed to the
+real `gmtsar/fitoffset.c` directly, per this repo's "everything outside
+`gmtsar/python/` is upstream and stays untouched for clean merges" rule.
+
+## Two more real bugs, found by the conda-full clean-room test itself
+
+- `CONDA_FORGE_BOOTSTRAP_PACKAGES` never listed `pip` explicitly —
+  `python` is pulled in transitively (via `gdal`'s python bindings, a
+  `gmt` dependency) but `pip` is not guaranteed to be. A genuinely
+  fresh env (either `conda` or `conda-full`) hit `FileNotFoundError` on
+  `bin/pip` during `do_python_deps` — every earlier manual test this
+  session happened to reuse a pre-existing env that already had `pip`
+  from unrelated prior setup, masking this until an actual from-scratch
+  env creation exposed it.
+- The FFTW threading shim build hardcoded literal `"gcc"` with no
+  `env=` passed, silently using the ambient PATH's (system) `gcc` even
+  under `--system conda-full` — defeating `conda-full`'s actual purpose
+  on a box with no system compiler at all. Now uses the resolved `CC`
+  from `build_env` when set, falling back to `"gcc"` only for plain
+  `conda`/`ubuntu`.
+
+## `locate_conda_env` prefers `micromamba` when present
+
+Real bug found during this session's own manual clean-room testing
+(before any of the above was wired in): classic `conda`'s solver
+(pre-libmamba-solver, e.g. `conda 4.14.0`) fell back from the fast
+repodata index to the full one and hung **28+ minutes with zero
+output** solving the real `CONDA_FORGE_BOOTSTRAP_PACKAGES` set — a
+known classic-solver failure mode on older hosts, not specific to any
+one package. `micromamba` (a standalone binary, no bootstrapping
+chicken-and-egg) solved and installed the identical package set in
+under a minute. `locate_conda_env()` now prefers `micromamba` for the
+actual `create` call when found on `PATH`, falling back to classic
+`conda create` (with a printed warning it may be slow) otherwise.
+
+This exposed a real test-isolation gap in an existing unit test
+(`test_locate_conda_env_creates_when_missing_at_resolved_base`), which
+mocked `install.run` but not `shutil.which` — a real `micromamba`
+happening to be on the test host's own `PATH` bypassed the test's fake
+conda mock entirely. Fixed by explicitly forcing the classic-conda path
+that test exercises; added a new test,
+`test_locate_conda_env_prefers_micromamba_when_present`, covering the
+micromamba path itself (not previously covered at all).
+
+## `install.py --system conda`: fail-fast pre-flight check for missing system build tools
+
+Plain `--system conda` deliberately assumes the system already
+provides `gfortran`/`g++`/`make`/`autoconf`/`csh`/`ghostscript` (see
+`do_conda_setup`'s docstring). No pre-flight check existed for this —
+a missing tool surfaced as a cryptic `autoconf`/`make` error deep
+inside the build. `_check_system_build_tools()` now checks up front and
+exits with a clear, actionable message naming exactly which tools are
+missing and how to install them.
+
+## Housekeeping: stale `insarhub-api` scaffold removed
+
+A v0 `GMTSAR_S1` processor scaffold was staged directly in this repo
+before InSARHub development moved to the dedicated
+`dunyuliu/InSARHub-GMTSAR-dev` fork (this repo stays at its own version
+line per project direction). Dead weight, removed.
+
+## Renamed `--system conda-full` -> `conda-linux-full`; platform scope documented for both conda modes
+
+Neither conda-backed `--system` choice had ever documented what
+platforms it actually covers.
+
+- `conda-linux-full` is genuinely Linux x86_64-only — conda-forge's
+  compiler-activation packages are per-target
+  (`gfortran_linux-64`/`gxx_linux-64`), macOS/ARM would need entirely
+  different package names, not implemented here. Renamed from
+  `conda-full` to make this explicit in the flag itself.
+  `_check_conda_linux_full_platform()` fails fast with a clear message
+  on any other platform, instead of `conda create` silently erroring
+  on unknown package names.
+- Plain `--system conda` was never actually Linux-restricted — it
+  defers entirely to whatever compiler is already on the system's
+  `PATH` (Homebrew's `gfortran`/`gcc` on macOS works the same as a
+  Linux distro's apt-installed ones), and every package in
+  `CONDA_FORGE_BOOTSTRAP_PACKAGES` has cross-platform conda-forge
+  builds. Just never documented which platforms it actually covers
+  until now.
+
+## Release-boundary verification (this release)
+
+`tests/test_install.py --system conda --full` (fresh clone, fresh
+conda env, per Rule 15) run at HEAD:
+
+- `install.py` real build+install: **PASS in 82.3s**.
+- `gmtsar_sharedir.csh` (upstream sanity check): **PASS**.
+- `bin_py/tests/` (620 tests): initially caught the real
+  `micromamba`-preference test-isolation regression above (1 failed,
+  560 passed, 59 skipped) — fixed and re-verified standalone (14/14 in
+  `test_install_config.py`, the file containing both the fix and the
+  new coverage) before the sweep phase; the clean-room clone under test
+  predates that fix commit, so its own `bin_py/tests/` run still shows
+  the pre-fix failure — a real, separately-confirmed-fixed issue, not
+  a live gap.
+- `sweep.py --full` (all 21 real py-vs-csh cases, ~3h wall):
+  **152/161 comparisons SUCCESS**. Two real failure clusters,
+  both root-caused, neither caused by anything in this release:
+  - `ALOS_haiti`: `los_ll.grd` — the same accepted flake documented in
+    `v2.8.0`'s release notes (inherent snaphu cycle-slip
+    nondeterminism, not a code bug).
+  - `S1_Ridgecrest_EQ`: 8 failures, all `F1`/`F2`/`F3`/`H_res`
+    intf-level files. Root-caused directly: the cached csh reference
+    ("oracle") for this case is missing its `F1`/`F2`/`F3` directories
+    entirely (confirmed via `ls` — they don't exist on the csh side at
+    all, while the Python side has complete, real output at the same
+    paths), has no `.oracle_built` sentinel, and the sweep itself
+    flagged it live: `WARN: oracle has no sentinel (.oracle_built) —
+    grandfathered as valid`. A stale/incomplete cached csh oracle
+    predating whatever expanded this case's comparison scope to
+    include `F1`/`F2`/`F3` — a real, pre-existing test-infrastructure
+    gap, not a regression from anything in this release. Needs a real
+    csh oracle rebuild for `S1_Ridgecrest_EQ` to resolve — tracked as a
+    follow-up, not done this release (would need real, multi-hour csh
+    processing time beyond this release's scope).
+- `--system conda-linux-full` itself: confirmed via multiple real
+  clean-room builds this session (fresh clone + fresh env each time) —
+  real binaries (`esarp`, `xcorr`, `phasefilt`, `p2p_processing`, ...)
+  built, linked, and ran correctly, `ldd` showed zero missing shared
+  libraries, `gmt --version`/`gmt grdinfo` both worked from the
+  fully-isolated env. Not yet covered by `tests/test_install.py`
+  itself (`--system` choices there are still `{ubuntu, conda}` only) —
+  a real follow-up, not done this release.
+
+## Commits
+
+`4ba030f`..`3fa0fbf` (9 commits since `v2.8.0`).

--- a/gmtsar/python/install.py
+++ b/gmtsar/python/install.py
@@ -8,26 +8,71 @@ Install location: the existing clone. This script never re-clones and
 never installs system-wide. `make install` lands in <repo>/bin via
 --prefix=<repo>.
 
-Both --system choices work on a brand-new box (nothing pre-installed
-beyond the OS package manager, or an already-installed Miniconda/Anaconda):
+All four --system choices work on a brand-new box (nothing
+pre-installed beyond the OS package manager, or an already-installed
+Miniconda/Anaconda):
 
 --system (pick exactly one):
-    ubuntu    apt-install system deps (REQUIRES SUDO). Provisions
-              everything: gmt, gfortran, g++, make, autoconf, csh,
-              ghostscript, libtiff, libhdf5, liblapack, ...
-    conda     use a conda env (no sudo). Set CONDA_GMTSAR_ENV (or
-              --conda-env) to pick which env (default: 'gmtsar'). If the
-              env doesn't exist yet, it's created via `conda create -c
-              conda-forge gmt hdf5 libtiff liblapack ...` (network
-              required, also bootstraps flex -- see do_conda_setup's
-              docstring for why flex specifically is conda-provisioned
-              rather than assumed). Still assumes the system already
-              has basic build tools (gfortran, g++, make, autoconf,
-              csh, ghostscript) -- --system conda deliberately keeps the
-              SYSTEM compiler in use rather than conda's (see
-              do_conda_setup's docstring), so it is not a fully
-              from-scratch bootstrap on a bare OS image the way
-              --system ubuntu is.
+    ubuntu      apt-install system deps (REQUIRES SUDO). Provisions
+                everything: gmt, gfortran, g++, make, autoconf, csh,
+                ghostscript, libtiff, libhdf5, liblapack, ...
+    conda       use a conda env (no sudo). NOT restricted to Linux --
+                unlike conda-linux-full below, this defers entirely to
+                whatever compiler is already on the system's PATH
+                (Homebrew's gfortran/gcc on macOS works just as well as
+                a Linux distro's apt-installed ones), and every package
+                in CONDA_FORGE_BOOTSTRAP_PACKAGES has cross-platform
+                conda-forge builds -- it was just never documented
+                which platforms this actually covers until now. Set
+                CONDA_GMTSAR_ENV (or --conda-env) to pick which env
+                (default: 'gmtsar'). If the env doesn't exist yet, it's
+                created via `conda create -c conda-forge gmt hdf5
+                libtiff liblapack ...` (network required, also
+                bootstraps flex -- see do_conda_setup's docstring for
+                why flex specifically is conda-provisioned rather than
+                assumed). Still assumes the system already has basic
+                build tools (gfortran, g++, make, autoconf, csh,
+                ghostscript) -- --system conda deliberately keeps the
+                SYSTEM compiler in use rather than conda's (see
+                do_conda_setup's docstring), so it is not a fully
+                from-scratch bootstrap on a bare OS image the way
+                --system ubuntu or conda-linux-full are.
+    conda-linux-full
+                like conda, but the compiler/build-tool chain is ALSO
+                conda-provided (gfortran_linux-64, gxx_linux-64, make,
+                autoconf, ghostscript, tcsh) -- genuinely no system
+                packages required at all beyond a bare conda/miniconda
+                install. LINUX x86_64 ONLY -- conda-forge's compiler
+                packages are per-target (gfortran_linux-64 etc; macOS
+                would need entirely different package names, e.g.
+                clang_osx-64/gfortran_osx-64, not implemented here).
+                Fails fast with a clear error on any other platform
+                rather than silently trying wrong package names.
+                Confirmed working via a real clean-room build,
+                2026-07-23 (see docs/PATHWAY_FORWARD.md). No plain `csh`
+                package exists on conda-forge (only `tcsh`, which
+                Debian/Ubuntu's own `csh` package itself just wraps) --
+                a `csh -> tcsh` symlink is created inside the env's
+                bin/ automatically. See do_conda_setup's docstring for
+                what "full isolation" actually means here (real env
+                activation, not just extra PATH/CPPFLAGS/LDFLAGS).
+    conda-windows-full
+                native Windows -- no WSL, no MSYS2/Cygwin toolchain, no
+                admin/sudo. Named to match conda-linux-full: like that
+                mode, the compiler/build-tool chain is ALSO conda-
+                provided (m2w64-toolchain, cmake, ninja), since a bare
+                Windows box has no "system gfortran/g++" to fall back
+                on the way --system conda does on Linux/macOS -- there
+                is no partial/non-full Windows variant. Builds via
+                CMake/Ninja (this repo's ./configure && make path is
+                POSIX-shell/Makefile-only) against the conda env's
+                MinGW-w64 toolchain. Still requires Git for Windows
+                installed separately (for a real POSIX shell --
+                gmtsar_lib.py shells out via Git Bash for syntax
+                cmd.exe can't run) -- gmtsar/python/
+                distribute_gmtsar_windows.py packages a fully self-
+                contained bundle (bundled Git Bash included) for
+                machines without it.
 
 `--system` alone installs everything for that system: dependencies, Python
 packages, and the in-place build. Two optional add-ons:
@@ -46,7 +91,10 @@ from __future__ import annotations
 
 import argparse
 import datetime
+import json
 import os
+import platform
+import re
 import shutil
 import stat
 import subprocess
@@ -112,6 +160,14 @@ BIN_PY_NAMES = [
 ]
 
 CONDA_SEARCH_BASES = ["~/anaconda3", "~/miniconda3", "/opt/conda"]
+
+IS_WINDOWS = sys.platform == "win32"
+# Extra search bases beyond CONDA_SEARCH_BASES for --system conda-windows-full:
+# ~/anaconda3 etc. still apply (expands to C:\Users\<user>\anaconda3), but
+# Windows installs are commonly placed elsewhere (e.g. a non-system drive)
+# with no shell init sourced, so $CONDA_EXE/`conda` on PATH may be unset --
+# check the usual non-home install roots too.
+WINDOWS_CONDA_SEARCH_BASES = [r"C:\ProgramData\Anaconda3", r"C:\ProgramData\miniconda3"]
 
 
 def _utc_now() -> str:
@@ -179,7 +235,10 @@ def require_apt() -> None:
 
 
 def _find_existing_conda_env(envname: str) -> Path | None:
-    for base in CONDA_SEARCH_BASES:
+    bases = list(CONDA_SEARCH_BASES)
+    if IS_WINDOWS:
+        bases += WINDOWS_CONDA_SEARCH_BASES
+    for base in bases:
         candidate = Path(os.path.expanduser(base)) / "envs" / envname
         if candidate.is_dir():
             return candidate
@@ -197,9 +256,15 @@ def locate_conda_base() -> Path:
     found = shutil.which("conda")
     if found:
         return Path(found).resolve().parent.parent
-    for base in CONDA_SEARCH_BASES:
+    bases = list(CONDA_SEARCH_BASES)
+    if IS_WINDOWS:
+        bases += WINDOWS_CONDA_SEARCH_BASES
+    for base in bases:
         b = Path(os.path.expanduser(base))
-        if (b / "bin" / "conda").is_file():
+        # Windows conda installs a launcher at condabin\conda.bat (Scripts\
+        # conda.exe also exists but only works once the env is active) --
+        # bin/conda is the POSIX layout.
+        if (b / "bin" / "conda").is_file() or (b / "condabin" / "conda.bat").is_file():
             return b
     sys.exit(
         "ERROR: no conda installation found (checked $CONDA_EXE, PATH, "
@@ -262,14 +327,81 @@ def locate_conda_base() -> Path:
 CONDA_FORGE_BOOTSTRAP_PACKAGES = [
     "gmt=6.4", "gshhg-gmt", "dcw-gmt", "flex",
     "hdf5=1.12.*", "libtiff>=4.5,<5", "liblapack>=3.9",
+    # Real bug found 2026-07-23 (a genuine --system conda-linux-full clean-room
+    # env creation, not a fixture): python itself is pulled in
+    # transitively (via gdal's python bindings, a gmt dependency), but
+    # pip is NOT -- do_python_deps's `pip install -r requirements.txt`
+    # then fails with FileNotFoundError on bin/pip. Only went unnoticed
+    # on plain --system conda so far because every real test this
+    # session reused a pre-existing env that already had pip from an
+    # earlier, unrelated setup -- a genuinely fresh env for EITHER mode
+    # hits this. Listed explicitly rather than relying on transitive
+    # pull-in, which is not guaranteed to include pip on every channel/
+    # solver combination.
+    "pip",
+]
+
+# --system conda-linux-full only: the compiler/build-tool chain --system conda
+# otherwise assumes the system already provides. conda-forge names its
+# compiler-activation packages per-target (gfortran_linux-64 etc, not
+# plain "gfortran") -- see do_conda_setup's docstring for why activation
+# is required to actually use them. No plain "csh" package exists on
+# conda-forge (confirmed 2026-07-23: only "tcsh" is published) -- a
+# csh -> tcsh symlink is created in the env's bin/ separately, not
+# listed here since it isn't a package.
+CONDA_FORGE_FULL_ISOLATION_PACKAGES = [
+    "gfortran_linux-64", "gxx_linux-64", "make", "autoconf",
+    "ghostscript", "tcsh",
 ]
 
 
-def locate_conda_env(envname: str) -> Path:
+def _resolve_current_conda_env() -> tuple[str, Path]:
+    """Resolve --conda-env current to (name, exact prefix path) of
+    whatever conda env is already active in this shell, via
+    $CONDA_DEFAULT_ENV (set by `conda activate`/`micromamba activate`,
+    not just $CONDA_PREFIX -- the latter is set even for 'base' with no
+    real activation) and $CONDA_PREFIX (the authoritative real path --
+    see locate_conda_env's known_prefix param for why this is used
+    directly instead of re-deriving the path by searching for the name).
+
+    Real feature request (2026-07-23, a downstream consumer -- InSARHub
+    -- testing this project): install.py always created/used a separate
+    'gmtsar'-named env, even when the caller was already inside a conda
+    env they wanted GMTSAR installed into directly (e.g. to share one
+    env across two projects' dependencies, avoiding version conflicts
+    between two separate envs each pinning their own numpy/gdal)."""
+    name = os.environ.get("CONDA_DEFAULT_ENV")
+    prefix = os.environ.get("CONDA_PREFIX")
+    if not name or name == "base" or not prefix:
+        sys.exit(
+            "ERROR: --conda-env current requires an activated (non-base) "
+            f"conda env in this shell -- $CONDA_DEFAULT_ENV is {name!r}, "
+            f"$CONDA_PREFIX is {prefix!r}. Run `conda activate <env>` "
+            "first, or pass a real env name instead of 'current'."
+        )
+    print(f"==> --conda-env current resolved to '{name}' at {prefix} "
+          f"(from $CONDA_DEFAULT_ENV/$CONDA_PREFIX)")
+    return name, Path(prefix)
+
+
+def locate_conda_env(envname: str, packages: list[str] | None = None,
+                      known_prefix: Path | None = None) -> Path:
     """Find an existing conda env named `envname`; if none exists, create
     it via `conda create -c conda-forge ...` so --system conda works on a
     brand-new host that already has *some* conda install but not yet the
-    'gmtsar' env (network required for the create step).
+    'gmtsar' env (network required for the create step). `packages`
+    defaults to CONDA_FORGE_BOOTSTRAP_PACKAGES; --system conda-linux-full passes
+    the extended list (+ CONDA_FORGE_FULL_ISOLATION_PACKAGES).
+
+    known_prefix: --conda-env current's exact path (from $CONDA_PREFIX),
+    used AS-IS instead of re-searching CONDA_SEARCH_BASES by name. The
+    search-by-name path below only checks a fixed set of common conda
+    install locations (see the incident this docstring already documents
+    for locate_conda_base) -- a currently-active env could legitimately
+    live under a completely different, non-standard root (a custom conda
+    install, a project-specific micromamba root, etc.), so re-deriving
+    its path by name when the real path is already known via activation
+    is both unnecessary and a real way to silently pick the wrong env.
 
     Real bug fixed 2026-07-13 (found by a genuine clean-room test, not
     a fixture): _find_existing_conda_env() only ever checks the fixed
@@ -282,22 +414,42 @@ def locate_conda_env(envname: str) -> Path:
     exited 0 but the env still doesn't exist" even though it does. The
     post-create check (and a pre-create check) must look under the
     SAME conda_base that locate_conda_base() actually resolved, not a
-    separately-guessed list."""
+    separately-guessed list.
+
+    Prefers `micromamba` for the actual create call, if present on PATH,
+    over classic `conda create`. Real bug found 2026-07-23 (a genuine
+    clean-room --system conda-linux-full attempt, not a fixture): classic
+    conda's solver (pre-libmamba-solver conda, e.g. 4.14.0) fell back
+    from the fast repodata index to the full one and hung 28+ minutes
+    with zero output solving this exact package set -- a known classic-
+    solver failure mode, not specific to any one package. micromamba
+    solved and installed the same set in well under a minute."""
+    if known_prefix is not None:
+        if not known_prefix.is_dir():
+            sys.exit(f"ERROR: known_prefix {known_prefix} does not exist.")
+        return known_prefix
     existing = _find_existing_conda_env(envname)
     if existing is not None:
         return existing
+    packages = packages if packages is not None else CONDA_FORGE_BOOTSTRAP_PACKAGES
     conda_base = locate_conda_base()
     # conda_base may not be one of CONDA_SEARCH_BASES -- check its own
     # envs/ dir directly before assuming a fresh create is needed.
     candidate = conda_base / "envs" / envname
     if candidate.is_dir():
         return candidate
+    creator = shutil.which("micromamba")
+    creator_desc = f"{creator} create" if creator else f"{conda_base}/bin/conda create"
     print(f"==> conda env '{envname}' not found; creating it via "
-          f"{conda_base}/bin/conda create -c conda-forge "
-          f"{' '.join(CONDA_FORGE_BOOTSTRAP_PACKAGES)} "
-          "(this downloads packages -- needs network, may take a while)...")
-    run([str(conda_base / "bin" / "conda"), "create", "-n", envname, "-y",
-         "-c", "conda-forge"] + CONDA_FORGE_BOOTSTRAP_PACKAGES)
+          f"{creator_desc} -c conda-forge {' '.join(packages)} "
+          "(this downloads packages -- needs network, may take a while"
+          f"{'' if creator else ', and classic conda can be SLOW -- consider installing micromamba if this hangs'})...")
+    if creator:
+        run([creator, "create", "-y", "-r", str(conda_base), "-n", envname,
+             "-c", "conda-forge"] + packages)
+    else:
+        run([str(conda_base / "bin" / "conda"), "create", "-n", envname, "-y",
+             "-c", "conda-forge"] + packages)
     if not candidate.is_dir():
         sys.exit(
             f"ERROR: conda create exited 0 but {candidate} still doesn't "
@@ -306,10 +458,27 @@ def locate_conda_env(envname: str) -> Path:
     return candidate
 
 
+def _stage_one_windows(src: Path, dst: Path) -> None:
+    """Windows has no reliable unprivileged symlink (needs Developer Mode
+    or admin, neither guaranteed) -- copy instead. Also normalizes CRLF
+    to LF: `git config core.autocrlf=true` (this checkout's setting)
+    rewrites every text file's line endings on checkout, which breaks
+    the `#!/usr/bin/env python3` shebang line real Windows tools (Git
+    Bash) use to exec these extensionless scripts -- `python3\\r` is not
+    a valid interpreter name. Copying is also why --rebuild exists: a
+    Windows install does NOT pick up source edits live the way the
+    symlink-based POSIX path does."""
+    data = src.read_bytes()
+    if b"\r\n" in data[:4096]:  # cheap check: only touch text-ish files
+        data = data.replace(b"\r\n", b"\n")
+    dst.write_bytes(data)
+
+
 def stage_execs(paths: list[Path], bin_dir: Path) -> None:
     """chmod +x each existing regular file, then symlink it into bin_dir
     (not copy, so edits to the source tree are picked up live). Shared by
-    every "stage these onto PATH" step in --build.
+    every "stage these onto PATH" step in --build. On Windows, copies
+    instead (see _stage_one_windows).
 
     Directories in `paths` (e.g. utils/__pycache__, utils/build -- a glob
     over utils/* picks these up too) are skipped, not staged: they were
@@ -328,7 +497,11 @@ def stage_execs(paths: list[Path], bin_dir: Path) -> None:
                   "exists as a real directory, not a symlink; remove it "
                   "manually if it shouldn't be there.", file=sys.stderr)
             continue
-        dst.symlink_to(f)
+        if IS_WINDOWS:
+            _stage_one_windows(f, dst)
+            dst.chmod(dst.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        else:
+            dst.symlink_to(f)
 
 
 def do_ubuntu_deps() -> None:
@@ -339,24 +512,130 @@ def do_ubuntu_deps() -> None:
     run(sudo + ["apt", "install", "-y"] + APT_SYSTEM_DEPS)
 
 
-def do_conda_setup(conda_env: str) -> tuple[Path, dict[str, str]]:
+# Real system build tools --system conda deliberately assumes are already
+# present (see do_conda_setup's docstring for why) rather than provisioning
+# them itself the way --system ubuntu does via apt. Checked up front so a
+# missing one fails fast with a clear message, instead of surfacing as a
+# cryptic autoconf/make error deep inside the build.
+REQUIRED_SYSTEM_BUILD_TOOLS = ("gfortran", "g++", "make", "autoconf", "csh", "gs")
+# "gs" is the actual binary name for ghostscript.
+
+def _check_system_build_tools() -> None:
+    missing = [t for t in REQUIRED_SYSTEM_BUILD_TOOLS if shutil.which(t) is None]
+    if missing:
+        sys.exit(
+            "ERROR: --system conda still requires these system build tools "
+            f"on PATH (not provisioned by conda): {', '.join(missing)}. "
+            "Install them via your OS package manager (e.g. on Ubuntu: "
+            "apt install gfortran g++ make autoconf csh ghostscript), then "
+            "re-run. See install.py's --system conda docstring for why "
+            "these aren't conda-provisioned."
+        )
+
+
+def _find_conda_compiler(prefix: Path, kind: str) -> str | None:
+    """Find conda-forge's target-triplet-prefixed compiler binary (e.g.
+    x86_64-conda-linux-gnu-gcc) under prefix/bin -- conda-forge's
+    *_linux-64 compiler-activation packages don't install plain-named
+    gcc/g++/gfortran, only these (meant to be picked up via env
+    activation, which sets CC/CXX/F77 to them -- see this function's
+    caller). `kind` is one of "gcc", "g++", "gfortran"."""
+    matches = sorted((prefix / "bin").glob(f"*-{kind}"))
+    return str(matches[0]) if matches else None
+
+
+def _check_conda_linux_full_platform() -> None:
+    """--system conda-linux-full only works on Linux x86_64:
+    CONDA_FORGE_FULL_ISOLATION_PACKAGES names conda-forge's per-target
+    compiler-activation packages (gfortran_linux-64, gxx_linux-64) --
+    macOS needs entirely different package names (e.g. clang_osx-64,
+    gfortran_osx-64), not implemented here. Checked up front so this
+    fails with a clear message instead of `conda create` silently
+    erroring on unknown package names for the wrong platform."""
+    system = platform.system()
+    machine = platform.machine()
+    if system != "Linux" or machine not in ("x86_64", "AMD64"):
+        sys.exit(
+            f"ERROR: --system conda-linux-full only supports Linux x86_64 "
+            f"(detected {system} {machine}). Its compiler packages "
+            f"(gfortran_linux-64, gxx_linux-64) are Linux-specific conda-forge "
+            f"names -- macOS/ARM would need different packages, not "
+            f"implemented here. Use --system conda instead (assumes the "
+            f"system's own compiler, which works on any platform)."
+        )
+
+
+def _check_conda_full_isolation_tools(prefix: Path) -> dict[str, str]:
+    """Verify the env actually has the full-isolation compiler/build-tool
+    set (whether just-created or a pre-existing env being reused), and
+    return the resolved {CC, CXX, F77} paths. Ensures a csh -> tcsh
+    symlink exists in prefix/bin (no plain csh package on conda-forge --
+    see CONDA_FORGE_FULL_ISOLATION_PACKAGES's comment)."""
+    cc = _find_conda_compiler(prefix, "gcc")
+    cxx = _find_conda_compiler(prefix, "g++")
+    f77 = _find_conda_compiler(prefix, "gfortran")
+    missing = []
+    if cc is None:
+        missing.append("gfortran_linux-64/gxx_linux-64 (C compiler)")
+    if cxx is None:
+        missing.append("gxx_linux-64 (C++ compiler)")
+    if f77 is None:
+        missing.append("gfortran_linux-64 (Fortran compiler)")
+    for tool in ("make", "autoconf", "gs"):
+        if not (prefix / "bin" / tool).is_file():
+            missing.append(tool)
+    if missing:
+        sys.exit(
+            f"ERROR: conda env at {prefix} is missing full-isolation "
+            f"build tools: {', '.join(missing)}. Either recreate the env "
+            f"(delete it and re-run --system conda-linux-full) or manually "
+            f"`conda install -n <env> -c conda-forge "
+            f"{' '.join(CONDA_FORGE_FULL_ISOLATION_PACKAGES)}`."
+        )
+    csh_link = prefix / "bin" / "csh"
+    if not csh_link.exists():
+        tcsh = prefix / "bin" / "tcsh"
+        if not tcsh.is_file():
+            sys.exit(f"ERROR: {tcsh} not found -- conda env is missing tcsh.")
+        csh_link.symlink_to(tcsh)
+        print(f"==> Created {csh_link} -> tcsh (no plain csh package on conda-forge)")
+    return {"CC": cc, "CXX": cxx, "F77": f77}
+
+
+def do_conda_setup(conda_env: str, full_isolation: bool = False,
+                    known_prefix: Path | None = None) -> tuple[Path, dict[str, str]]:
     """Locate (or create, if missing -- see locate_conda_env) the conda
     env, then return its libs/includes as an explicit env-var dict for
     do_build to pass ONLY to the subprocess calls that need them --
     WITHOUT activating the env or mutating this process's own
-    os.environ, so system gfortran/gcc stay in use (full conda
-    activation pollutes CC/F77 and breaks configure) and so these
-    build flags don't silently leak into every other subprocess this
-    script runs. This is why --system conda still assumes the system's
-    own compiler/build-tool chain (gfortran, g++, make, autoconf, csh,
-    ghostscript) is already present, unlike --system ubuntu which
-    provisions all of that itself via apt. flex is the one exception --
-    bootstrapped via conda-forge instead of assumed present, since
-    (unlike a compiler) it has no ABI/linkage implications for the rest
-    of the build -- see CONDA_FORGE_BOOTSTRAP_PACKAGES's comment."""
-    prefix = locate_conda_env(conda_env)
+    os.environ, so system gfortran/gcc stay in use by default (full
+    conda activation pollutes CC/F77 and breaks configure UNLESS the
+    conda env's own compilers are what you actually want -- see
+    full_isolation below) and so these build flags don't silently leak
+    into every other subprocess this script runs. This is why plain
+    --system conda still assumes the system's own compiler/build-tool
+    chain (gfortran, g++, make, autoconf, csh, ghostscript) is already
+    present, unlike --system ubuntu which provisions all of that itself
+    via apt. flex is the one exception -- bootstrapped via conda-forge
+    instead of assumed present even in plain conda mode, since (unlike a
+    compiler) it has no ABI/linkage implications for the rest of the
+    build -- see CONDA_FORGE_BOOTSTRAP_PACKAGES's comment.
+
+    full_isolation=True (--system conda-linux-full): confirmed working via a
+    real clean-room build, 2026-07-23 (docs/PATHWAY_FORWARD.md). Uses
+    conda-forge's own gfortran_linux-64/gxx_linux-64 packages -- these
+    install target-triplet-prefixed binaries (x86_64-conda-linux-gnu-gcc
+    etc), not plain gcc/g++/gfortran, so CC/CXX/F77 are set explicitly
+    to those resolved paths (real activation-equivalent), same
+    subprocess-only-env-dict mechanism as the rest of this function --
+    still never mutates this process's own os.environ."""
+    packages = (CONDA_FORGE_BOOTSTRAP_PACKAGES + CONDA_FORGE_FULL_ISOLATION_PACKAGES
+                if full_isolation else CONDA_FORGE_BOOTSTRAP_PACKAGES)
+    prefix = locate_conda_env(conda_env, packages=packages, known_prefix=known_prefix)
     print(f"==> Using conda env at {prefix} (no sudo)")
+    compiler_env = _check_conda_full_isolation_tools(prefix) if full_isolation else {}
     extra_env = {
+        **compiler_env,
         "CPPFLAGS": f"-I{prefix}/include -I{prefix}/include/gmt",
         "LDFLAGS": f"-L{prefix}/lib -Wl,-rpath,{prefix}/lib",
         "PKG_CONFIG_PATH": f"{prefix}/lib/pkgconfig",
@@ -389,6 +668,252 @@ def do_conda_setup(conda_env: str) -> tuple[Path, dict[str, str]]:
     return prefix, extra_env
 
 
+# ------------------------------------------------------ conda-windows-full ----
+# Bootstrap set for --system conda-windows-full: same rationale as
+# CONDA_FORGE_BOOTSTRAP_PACKAGES (gmt pinned for numerical parity; libtiff
+# pinned since it's linked into the C build), PLUS the actual Windows-
+# native build toolchain (m2w64-toolchain: MinGW-w64 gcc/gfortran/make;
+# cmake+ninja: this repo's C build goes through CMake on Windows, not
+# ./configure && make -- see do_windows_build). No hdf5/flex: RS2/NISAR
+# (the only sensors this Windows path has been verified against) default
+# to their Python preprocessors (GMTSAR_RS2_PREPROC_PY / GMTSAR_NSR_
+# PREPROC_PY = 1 -- NISAR's HDF5 read goes through h5py, a pip package,
+# not the C libhdf5), never touching preproc/ERS_preproc's lex-generated
+# ers_line_fixer.c. openblas, NOT the default libblas/liblapack (those
+# resolve to an MKL build whose DLLs ship with no import .lib MinGW can
+# link against -- and even openblas needs a real workaround, a MinGW
+# binutils bug triggered by its huge symbol table; see gmtsar/CMakeLists.
+# txt's WIN32 block).
+WINDOWS_CONDA_BOOTSTRAP_PACKAGES = [
+    "gmt=6.4", "gshhg-gmt", "dcw-gmt", "libtiff>=4.5,<5", "openblas",
+    # Variant pins, not just the openblas package: on win-64, conda-forge's
+    # DEFAULT libblas/liblapack shim DLLs are the MKL variant -- their
+    # EXPORTS are forwarders to mkl_rt.N.dll, so anything linking the shims
+    # (conda's own gmt.dll does) needs the MKL runtime at load time even
+    # when openblas is co-installed. Real bug found 2026-07-23 by
+    # distribute_gmtsar_windows.py's isolated-PATH verify: gmt.dll failed
+    # STATUS_DLL_NOT_FOUND with every *import-table* dependency present,
+    # because forwarders live in the export table where no import walk
+    # sees them. MKL also can't be bundled statically (mkl_rt dispatches
+    # to mkl_core/mkl_avx*/... via runtime LoadLibrary). Pinning the
+    # openblas variant makes the shims forward to openblas.dll -- which
+    # this build already links directly (see gmtsar/CMakeLists.txt's
+    # WIN32 openblas import-lib workaround) -- and drops MKL from the
+    # env entirely (smaller, self-containable).
+    "libblas=*=*openblas", "liblapack=*=*openblas", "libcblas=*=*openblas",
+    "m2w64-toolchain", "cmake", "ninja",
+    # Same class of bug CONDA_FORGE_BOOTSTRAP_PACKAGES fixed in v2.9.0
+    # (see its own "pip" entry): python arrives transitively (gmt -> gdal
+    # -> python bindings) but pip is NOT guaranteed to -- and
+    # do_python_deps runs `python.exe -m pip install -r requirements.txt`,
+    # which dies with "No module named pip" on a genuinely fresh env.
+    # Every dev-machine test so far reused an env that already had pip
+    # from unrelated prior setup, masking this. Listing pip explicitly
+    # also guarantees python itself (pip depends on it).
+    "pip",
+]
+
+
+def _windows_env_paths(prefix: Path) -> dict[str, Path]:
+    """Windows conda envs use a different layout than POSIX: libraries/
+    headers/native binaries live under <prefix>/Library/, not <prefix>/
+    {lib,include,bin}; the env's own Python is <prefix>/python.exe (not
+    <prefix>/bin/python3); pip-installed console scripts land in
+    <prefix>/Scripts/, not <prefix>/bin/."""
+    library = prefix / "Library"
+    return {
+        "python": prefix / "python.exe",
+        "scripts": prefix / "Scripts",
+        "bin": library / "bin",
+        "include": library / "include",
+        "lib": library / "lib",
+        "mingw_bin": library / "mingw-w64" / "bin",
+        "cmake": library / "bin" / "cmake.exe",
+        "ninja": library / "bin" / "ninja.exe",
+    }
+
+
+def _windows_conda_exe(conda_base: Path) -> Path:
+    """Prefer Scripts\\conda.exe (a real PE executable, directly
+    CreateProcess-able) over condabin\\conda.bat. Real bug found
+    2026-07-23 by the first genuinely-fresh env creation (every earlier
+    run reused an existing env, so the create branch never executed):
+    the .bat route goes through `cmd /c`, and cmd PARSES the command
+    line -- a bare package spec like `libtiff>=4.5,<5` is read as
+    redirection operators (stdout to a file named `=4.5,`, stdin from a
+    file named `5`), failing in milliseconds with cmd's opaque 'The
+    system cannot find the file specified'. And it can't be cleanly
+    quoted from a subprocess argv list either: list2cmdline escapes
+    embedded quotes as \\", which cmd forwards through the .bat's %*
+    so the final conda argv gets LITERAL quote characters in the spec.
+    conda.exe sidesteps the whole class: no cmd, no metacharacter
+    parsing, list2cmdline handles it like any normal argv. (An earlier
+    docstring here claimed Scripts\\conda.exe 'only works once the env
+    is active' -- tested false on conda 26.5.3: --version, env list
+    --json, and create all work standalone.)"""
+    conda_scripts_exe = conda_base / "Scripts" / "conda.exe"
+    if conda_scripts_exe.is_file():
+        return conda_scripts_exe
+    return conda_base / "condabin" / "conda.bat"
+
+
+def _windows_conda_cmd(conda_exe: Path, args: list[str]) -> list[str]:
+    """conda.exe: direct argv, no shell involved. conda.bat (fallback
+    for exotic installs with no Scripts\\conda.exe): must go through
+    cmd /c -- CreateProcess can't exec a .bat -- which re-parses the
+    command line; package specs containing cmd metacharacters (>,<,,)
+    CANNOT be passed reliably through that route (see
+    _windows_conda_exe's docstring), so fail loudly up front rather
+    than let cmd misparse them into redirections."""
+    if conda_exe.suffix.lower() == ".exe":
+        return [str(conda_exe)] + args
+    bad = [a for a in args if re.search(r'[><|&^]', a)]
+    if bad:
+        sys.exit(
+            f"ERROR: only condabin\\conda.bat was found ({conda_exe}), and "
+            f"these arguments cannot be passed reliably through cmd /c: "
+            f"{bad}. Install a conda providing Scripts\\conda.exe, or "
+            "create the env manually and re-run.")
+    return ["cmd", "/c", str(conda_exe)] + args
+
+
+def _windows_conda_env_paths(conda_exe: Path) -> dict[str, str]:
+    """{env_name: env_path} via `conda env list --json` -- the
+    AUTHORITATIVE source, not directory-guessing. Real bug found
+    2026-07-23: conda's default envs_dirs includes ~/.conda/envs, a
+    location independent of where conda ITSELF is installed (e.g. conda
+    at D:\\anaconda but the env at C:\\Users\\<user>\\.conda\\envs\\gmtsar)
+    -- CONDA_SEARCH_BASES-style guessing (~/anaconda3, ~/miniconda3, ...)
+    missed a genuinely-existing env on the exact host this was built on."""
+    cmd = _windows_conda_cmd(conda_exe, ["env", "list", "--json"])
+    out = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    if out.returncode != 0:
+        sys.exit(f"ERROR: `conda env list --json` failed (rc={out.returncode}): {out.stderr}")
+    envs = json.loads(out.stdout).get("envs", [])
+    return {Path(p).name: p for p in envs}
+
+
+def _ensure_python3_shim(conda_prefix: Path) -> None:
+    """Every staged Python tool (utils/*, bin_py/*) starts with `#!/usr/
+    bin/env python3` -- and conda's Windows envs only ship python.exe,
+    never a `python3` alias. Without this, Git Bash's `env` resolves
+    `python3` to Windows' Microsoft-Store app-execution-alias stub
+    instead (a fake python3.exe that just prints "Python was not found;
+    run without arguments to install from the Microsoft Store" -- a
+    real, confirmed failure mode, not a hypothetical one), silently
+    breaking every single staged tool's shebang line. Copying python.exe
+    to python3.exe alongside it in the env root fixes this permanently:
+    that directory is exactly what `conda activate <env>` puts on PATH,
+    ahead of the WindowsApps alias directory."""
+    python3_exe = conda_prefix / "python3.exe"
+    if not python3_exe.is_file():
+        shutil.copy2(conda_prefix / "python.exe", python3_exe)
+        print(f"==> Created {python3_exe} (python3 shim -- see "
+              "_ensure_python3_shim)")
+
+
+def do_windows_conda_setup(conda_env: str) -> Path:
+    """Locate (or create) the conda env for --system conda-windows-full.
+    Unlike do_conda_setup (Linux), this does NOT keep a separate system
+    compiler in use -- a bare Windows box has no "system gfortran/gcc"
+    equivalent to fall back on, so the conda env supplies the WHOLE
+    toolchain (m2w64-toolchain) via WINDOWS_CONDA_BOOTSTRAP_PACKAGES."""
+    conda_base = locate_conda_base()
+    conda_exe = _windows_conda_exe(conda_base)
+
+    envs = _windows_conda_env_paths(conda_exe)
+    if conda_env in envs:
+        existing = Path(envs[conda_env])
+        print(f"==> Using conda env at {existing} (no sudo/admin)")
+        _ensure_python3_shim(existing)
+        return existing
+
+    print(f"==> conda env '{conda_env}' not found; creating it via "
+          f"{conda_exe} create -c conda-forge "
+          f"{' '.join(WINDOWS_CONDA_BOOTSTRAP_PACKAGES)} "
+          "(this downloads packages -- needs network, may take a while)...")
+    run(_windows_conda_cmd(conda_exe, ["create", "-n", conda_env, "-y",
+        "-c", "conda-forge"] + WINDOWS_CONDA_BOOTSTRAP_PACKAGES))
+
+    envs = _windows_conda_env_paths(conda_exe)
+    if conda_env not in envs:
+        sys.exit(
+            f"ERROR: conda create exited 0 but env '{conda_env}' still "
+            "doesn't show up in `conda env list --json` -- check the "
+            "conda output above."
+        )
+    new_prefix = Path(envs[conda_env])
+    _ensure_python3_shim(new_prefix)
+    return new_prefix
+
+
+def do_windows_build(conda_prefix: Path) -> None:
+    """Windows equivalent of do_build(): this repo's ./configure && make
+    path is POSIX-shell/Makefile-only and doesn't target Windows library
+    layouts -- build via the repo's CMakeLists.txt (Ninja generator)
+    against the conda env's MinGW-w64 toolchain instead. Only covers the
+    C/CMake side; RS2/NISAR/etc's actual pipelines run through the
+    Python framework (utils/), staged below same as do_build's tail."""
+    paths = _windows_env_paths(conda_prefix)
+    for label in ("cmake", "ninja"):
+        if not paths[label].is_file():
+            sys.exit(f"ERROR: {paths[label]} not found -- was "
+                      f"'{label}' installed into the '{conda_prefix.name}' "
+                      "conda env? (see WINDOWS_CONDA_BOOTSTRAP_PACKAGES)")
+
+    _apply_c_fixes()
+    print(f"==> Building gmtsar (CMake/Ninja) in {REPO_ROOT} ...")
+    build_dir = REPO_ROOT / "build-win"
+    build_dir.mkdir(exist_ok=True)
+
+    build_env = dict(os.environ)
+    # mingw_bin first: cc.exe's own subprocess tools (cc1.exe, as.exe,
+    # ...) must resolve from the SAME toolchain install, or the compiler
+    # can intermittently ICE -- a real bug hit during this port's own
+    # bring-up (cc.exe invoked without mingw-w64/bin on PATH crashed
+    # compiling a file it compiles fine otherwise).
+    build_env["PATH"] = os.pathsep.join([
+        str(paths["mingw_bin"]), str(paths["bin"]),
+        build_env.get("PATH", ""),
+    ])
+
+    run([str(paths["cmake"]), "-G", "Ninja",
+         "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+         "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
+         f"-DCMAKE_INSTALL_PREFIX={REPO_ROOT}",
+         str(REPO_ROOT)], cwd=str(build_dir), env=build_env)
+    run([str(paths["ninja"])], cwd=str(build_dir), env=build_env)
+    run([str(paths["cmake"]), "--install", str(build_dir)], env=build_env)
+
+    bin_dir = REPO_ROOT / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    py_utils = REPO_ROOT / "gmtsar" / "python" / "utils"
+    stage_execs(sorted(py_utils.iterdir()), bin_dir)
+
+    bin_py_dir = REPO_ROOT / "gmtsar" / "python" / "bin_py"
+    stage_execs([bin_py_dir / name for name in BIN_PY_NAMES], bin_dir)
+    # phasediff_py dynamically loads _gmt_native_bf.py from its own
+    # directory (importlib.util.spec_from_file_location(..., _HERE /
+    # "_gmt_native_bf.py")) -- on POSIX that resolves through the
+    # bin/phasediff_py symlink back to bin_py/, where the file already
+    # lives; Windows COPIES phasediff_py flatly into bin/ instead (see
+    # stage_execs/_stage_one_windows), so the sibling file has to be
+    # staged alongside it explicitly.
+    if (bin_py_dir / "_gmt_native_bf.py").is_file():
+        stage_execs([bin_py_dir / "_gmt_native_bf.py"], bin_dir)
+
+    csh_dir = REPO_ROOT / "gmtsar" / "csh"
+    stage_execs(sorted(csh_dir.glob("*.csh")), bin_dir)
+    csh_shims_dir = REPO_ROOT / "gmtsar" / "python" / "csh_shims"
+    if csh_shims_dir.is_dir():
+        stage_execs(sorted(csh_shims_dir.glob("*.csh")), bin_dir)
+
+    # fftw_force_serial.so is an LD_PRELOAD shim -- meaningless on
+    # Windows (no LD_PRELOAD mechanism); sweep.py/case_runner.py still
+    # set the env var when present, which is simply ignored. Not built
+    # here.
+
+
 def do_python_deps(use_conda: bool, conda_prefix: Path | None) -> None:
     if use_conda:
         requirements_txt = REPO_ROOT / "gmtsar" / "python" / "requirements.txt"
@@ -402,8 +927,14 @@ def do_python_deps(use_conda: bool, conda_prefix: Path | None) -> None:
         # install via this path left the framework broken out of the box.
         # Read from requirements.txt directly so the two lists can't
         # diverge again.
-        run([str(conda_prefix / "bin" / "pip"), "install", "--upgrade",
-             "-r", str(requirements_txt)])
+        if IS_WINDOWS:
+            # No bin/pip on Windows -- `python -m pip` is the portable
+            # invocation, works whether or not Scripts/pip.exe exists yet.
+            run([str(conda_prefix / "python.exe"), "-m", "pip", "install",
+                 "--upgrade", "-r", str(requirements_txt)])
+        else:
+            run([str(conda_prefix / "bin" / "pip"), "install", "--upgrade",
+                 "-r", str(requirements_txt)])
     else:
         require_apt()
         print("==> Installing Python packages via apt...")
@@ -519,6 +1050,47 @@ def _defuse_fake_lex_sources() -> None:
               f"committed {c_file.name}; see _defuse_fake_lex_sources)")
 
 
+# Real GMTSAR source bug found 2026-07-23 (a genuine --system conda-linux-full
+# clean-room build, not a fixture): gmtsar/fitoffset.c calls strlcpy()
+# with no declaration/include anywhere. Implicit-declaration is only a
+# WARNING on GCC < 14 (e.g. a system compiler), a HARD ERROR on GCC 14+
+# (conda-forge's gxx_linux-64 package is 15.2.0) -- GCC 14 promoted
+# implicit function declarations to an error by default, part of C23
+# alignment. NOT --system conda-linux-full-specific: will also break --system
+# ubuntu on any host with GCC 14+ (Ubuntu 24.10+, Fedora 40+, Arch
+# already do). Applying this fix universally, not just under
+# conda-linux-full, since it's a genuine correctness/portability fix with
+# identical behavior on old compilers too (confirmed: compiles clean on
+# both GCC 11.4.0 and 15.2.0). See gmtsar/python/c_fixes/README.md.
+#
+# Kept as a build-time patch (copied over the real file, not committed
+# there) rather than editing gmtsar/fitoffset.c directly, per this
+# repo's "everything outside gmtsar/python/ is upstream and stays
+# untouched for clean merges" rule -- the real fix belongs in
+# gmtsar/python/c_fixes/ under version control instead.
+C_FIXES = {
+    REPO_ROOT / "gmtsar" / "python" / "c_fixes" / "fitoffset.c":
+        REPO_ROOT / "gmtsar" / "fitoffset.c",
+    REPO_ROOT / "gmtsar" / "python" / "c_fixes" / "conv.c":
+        REPO_ROOT / "gmtsar" / "conv.c",
+}
+
+
+def _apply_c_fixes() -> None:
+    for src, dst in C_FIXES.items():
+        if not src.is_file():
+            continue
+        if dst.is_file() and dst.read_bytes() == src.read_bytes():
+            continue
+        if not dst.is_file():
+            print(f"WARN: c_fixes target {dst} does not exist -- skipping "
+                  f"(upstream file layout may have changed)", file=sys.stderr)
+            continue
+        shutil.copyfile(src, dst)
+        print(f"==> applied c_fixes: {dst.relative_to(REPO_ROOT)} "
+              f"(from {src.relative_to(REPO_ROOT)})")
+
+
 def do_build(use_conda: bool, conda_prefix: Path | None,
              extra_env: dict[str, str] | None = None) -> None:
     """extra_env (from do_conda_setup, empty for --system ubuntu) is
@@ -527,6 +1099,7 @@ def do_build(use_conda: bool, conda_prefix: Path | None,
     so it can't silently affect any other command this script runs."""
     print(f"==> Building gmtsar in {REPO_ROOT} ...")
     os.chdir(REPO_ROOT)
+    _apply_c_fixes()
     _defuse_fake_lex_sources()
     build_env = None
     if extra_env:
@@ -587,10 +1160,20 @@ def do_build(use_conda: bool, conda_prefix: Path | None,
     # runtime (LD_PRELOAD'd by runner.py). Without it, libgmt's
     # pthread-based FFTW spawns 14-19 threads per process and contends
     # across pipelines.
+    #
+    # Real gap found 2026-07-23 (--system conda-linux-full clean-room build):
+    # this used to hardcode literal "gcc" with no env= passed, so it
+    # silently used the ambient PATH's (system) gcc even under
+    # conda-linux-full -- on a box with genuinely no system compiler at all,
+    # that would fail despite conda-linux-full's whole point being not to need
+    # one. Uses the resolved CC from build_env when set (conda-linux-full),
+    # else falls back to "gcc" (plain conda / ubuntu, where the system
+    # compiler is assumed present anyway).
     py_dir = REPO_ROOT / "gmtsar" / "python"
-    run(["gcc", "-shared", "-fPIC", "-O2",
+    cc = (build_env or {}).get("CC", "gcc")
+    run([cc, "-shared", "-fPIC", "-O2",
          "-o", str(py_dir / "fftw_force_serial.so"),
-         str(py_dir / "fftw_force_serial.c")])
+         str(py_dir / "fftw_force_serial.c")], env=build_env)
 
 
 def do_orbits() -> None:
@@ -639,6 +1222,32 @@ def _setup_log(args: argparse.Namespace) -> None:
 
 
 def print_summary(conda_env: str) -> None:
+    if IS_WINDOWS:
+        print(f"""
+All requested steps completed.
+
+This pipeline shells out using POSIX syntax (ln -sf, rm -rf, mkdir -p,
+&&, ...) that cmd.exe/PowerShell can't run -- gmtsar_lib.py routes those
+through Git Bash (bash.exe) instead. Set GMTSAR_WIN_BASH if it isn't at
+the default C:\\Program Files\\Git\\bin\\bash.exe.
+
+To use gmtsar from this checkout, run in an Anaconda Prompt (cmd.exe):
+  conda activate {conda_env}
+  set GMTSAR={REPO_ROOT}
+  set PATH=%GMTSAR%\\bin;%PATH%
+
+(PowerShell: $env:GMTSAR="{REPO_ROOT}"; $env:PATH="$env:GMTSAR\\bin;$env:PATH")
+
+Sanity check:
+  where p2p_processing
+  gmt --version        # confirms gmt is reachable (needed for actual runs)
+  conv.exe             # should print usage, not crash -- if it segfaults,
+                        # the openblas link workaround (gmtsar/CMakeLists.txt,
+                        # WIN32 block) didn't take; re-run --rebuild.
+
+Full log of this run (every command, timestamped, with real output): {_LOG_PATH}
+""")
+        return
     print(f"""
 All requested steps completed.
 
@@ -663,14 +1272,26 @@ def main() -> None:
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("--system", choices=["ubuntu", "conda"],
+    parser.add_argument("--system", choices=["ubuntu", "conda", "conda-linux-full", "conda-windows-full"],
                         help="install everything for this system: system "
                              "deps (apt for ubuntu, a conda env -- created "
-                             "if missing -- for conda), Python packages, "
-                             "and the in-place build")
+                             "if missing -- for conda/conda-linux-full/"
+                             "conda-windows-full), Python packages, and the "
+                             "in-place build. conda-linux-full additionally "
+                             "provisions the compiler/build-tool chain via "
+                             "conda instead of assuming the system has it "
+                             "(see --system conda-linux-full in this "
+                             "script's own docstring). conda-windows-full is "
+                             "native Windows (no WSL, no sudo/admin) -- see "
+                             "do_windows_build")
     parser.add_argument("--conda-env", default="gmtsar",
-                        help="conda env name for --system conda "
-                             "(default: 'gmtsar')")
+                        help="conda env name for --system conda/conda-linux-full "
+                             "(default: 'gmtsar'). Pass 'current' to install into "
+                             "whatever conda env is already active in this shell "
+                             "(detected via $CONDA_DEFAULT_ENV) instead of "
+                             "creating/using a separate 'gmtsar'-named env -- "
+                             "errors clearly if no env is currently active "
+                             "(e.g. base, or no conda activation at all)")
     parser.add_argument("--rebuild", action="store_true",
                         help="skip the dependency steps, just rebuild + "
                              "re-stage (requires --system, for its build "
@@ -685,13 +1306,25 @@ def main() -> None:
         return
 
     if args.rebuild and args.system is None:
-        sys.exit("ERROR: --rebuild requires --system ubuntu or --system conda "
-                  "(needed to resolve build flags, e.g. the conda env's "
-                  "include/lib paths)")
+        sys.exit("ERROR: --rebuild requires --system ubuntu, conda, "
+                  "conda-linux-full, or conda-windows-full (needed to resolve "
+                  "build flags, e.g. the conda env's include/lib paths)")
+
+    if args.system == "conda-windows-full" and not IS_WINDOWS:
+        sys.exit("ERROR: --system conda-windows-full only makes sense when "
+                  f"running on Windows (sys.platform={sys.platform!r})")
+    if args.system in ("ubuntu", "conda", "conda-linux-full") and IS_WINDOWS:
+        sys.exit(f"ERROR: --system {args.system} targets POSIX (uses "
+                  "./configure && make, apt, etc.) -- use --system "
+                  "conda-windows-full on native Windows instead")
+
+    current_conda_prefix: Path | None = None
+    if args.conda_env == "current":
+        args.conda_env, current_conda_prefix = _resolve_current_conda_env()
 
     _setup_log(args)
 
-    use_conda = args.system == "conda"
+    use_conda = args.system in ("conda", "conda-linux-full", "conda-windows-full")
     conda_prefix: Path | None = None
     extra_env: dict[str, str] = {}
 
@@ -699,12 +1332,31 @@ def main() -> None:
         if not args.rebuild:
             do_ubuntu_deps()
     elif args.system == "conda":
-        conda_prefix, extra_env = do_conda_setup(args.conda_env)
+        _check_system_build_tools()
+        conda_prefix, extra_env = do_conda_setup(args.conda_env, known_prefix=current_conda_prefix)
+    elif args.system == "conda-linux-full":
+        # No _check_system_build_tools() -- conda-linux-full provisions the
+        # compiler/build-tool chain itself; do_conda_setup's own
+        # _check_conda_full_isolation_tools() verifies THAT instead.
+        _check_conda_linux_full_platform()
+        conda_prefix, extra_env = do_conda_setup(args.conda_env, full_isolation=True,
+                                                 known_prefix=current_conda_prefix)
+    elif args.system == "conda-windows-full":
+        # known_prefix/--conda-env current not wired into
+        # do_windows_conda_setup() yet -- it doesn't share
+        # locate_conda_env()'s machinery at all (see its own docstring:
+        # Windows can't fall back to a system compiler, so the whole
+        # toolchain comes from the env). Real follow-up, not done here.
+        conda_prefix = do_windows_conda_setup(args.conda_env)
 
-    if args.system is not None:
+    if args.system in ("ubuntu", "conda", "conda-linux-full"):
         if not args.rebuild:
             do_python_deps(use_conda, conda_prefix)
         do_build(use_conda, conda_prefix, extra_env)
+    elif args.system == "conda-windows-full":
+        if not args.rebuild:
+            do_python_deps(use_conda, conda_prefix)
+        do_windows_build(conda_prefix)
 
     if args.orbits:
         do_orbits()

--- a/gmtsar/python/license_texts/AGPL-3.0.txt
+++ b/gmtsar/python/license_texts/AGPL-3.0.txt
@@ -1,0 +1,235 @@
+GNU AFFERO GENERAL PUBLIC LICENSE
+Version 3, 19 November 2007
+
+Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+                            Preamble
+
+The GNU Affero General Public License is a free, copyleft license for software and other kinds of works, specifically designed to ensure cooperation with the community in the case of network server software.
+
+The licenses for most software and other practical works are designed to take away your freedom to share and change the works.  By contrast, our General Public Licenses are intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users.
+
+When we speak of free software, we are referring to freedom, not price.  Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things.
+
+Developers that use our General Public Licenses protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License which gives you legal permission to copy, distribute and/or modify the software.
+
+A secondary benefit of defending all users' freedom is that improvements made in alternate versions of the program, if they receive widespread use, become available for other developers to incorporate.  Many developers of free software are heartened and encouraged by the resulting cooperation.  However, in the case of software used on network servers, this result may fail to come about. The GNU General Public License permits making a modified version and letting the public access it on a server without ever releasing its source code to the public.
+
+The GNU Affero General Public License is designed specifically to ensure that, in such cases, the modified source code becomes available to the community.  It requires the operator of a network server to provide the source code of the modified version running there to the users of that server.  Therefore, public use of a modified version, on a publicly accessible server, gives the public access to the source code of the modified version.
+
+An older license, called the Affero General Public License and published by Affero, was designed to accomplish similar goals.  This is a different license, not a version of the Affero GPL, but Affero has released a new version of the Affero GPL which permits relicensing under this license.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+                       TERMS AND CONDITIONS
+
+0. Definitions.
+
+"This License" refers to version 3 of the GNU Affero General Public License.
+
+"Copyright" also means copyright-like laws that apply to other kinds of works, such as semiconductor masks.
+
+"The Program" refers to any copyrightable work licensed under this License.  Each licensee is addressed as "you".  "Licensees" and "recipients" may be individuals or organizations.
+
+To "modify" a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy.  The resulting work is called a "modified version" of the earlier work or a work "based on" the earlier work.
+
+A "covered work" means either the unmodified Program or a work based on the Program.
+
+To "propagate" a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy.  Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well.
+
+To "convey" a work means any kind of propagation that enables other parties to make or receive copies.  Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying.
+
+An interactive user interface displays "Appropriate Legal Notices" to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License.  If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion.
+
+1. Source Code.
+The "source code" for a work means the preferred form of the work for making modifications to it.  "Object code" means any non-source form of a work.
+
+A "Standard Interface" means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language.
+
+The "System Libraries" of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form.  A "Major Component", in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it.
+
+The "Corresponding Source" for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities.  However, it does not include the work's System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work.  For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source.
+
+The Corresponding Source for a work in source code form is that same work.
+
+2. Basic Permissions.
+All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met.  This License explicitly affirms your unlimited permission to run the unmodified Program.  The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work.  This License acknowledges your rights of fair use or other equivalent, as provided by copyright law.
+
+You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force.  You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright.  Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you.
+
+Conveying under any other circumstances is permitted solely under the conditions stated below.  Sublicensing is not allowed; section 10 makes it unnecessary.
+
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures.
+
+When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work's users, your or third parties' legal rights to forbid circumvention of technological measures.
+
+4. Conveying Verbatim Copies.
+You may convey verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program.
+
+You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee.
+
+5. Conveying Modified Source Versions.
+You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is released under this License and any conditions added under section 7.  This requirement modifies the requirement in section 4 to "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy.  This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged.  This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so.
+
+A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an "aggregate" if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation's users beyond what the individual works permit.  Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate.
+
+6. Conveying Non-Source Forms.
+You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source.  This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b.
+
+    d) Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge.  You need not require recipients to copy the Corresponding Source along with the object code.  If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source.  Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d.
+
+A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work.
+
+A "User Product" is either (1) a "consumer product", which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling.  In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage.  For a particular product received by a particular user, "normally used" refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product.  A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product.
+
+"Installation Information" for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source.  The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made.
+
+If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information.  But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM).
+
+The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed.  Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network.
+
+Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying.
+
+7. Additional Terms.
+"Additional permissions" are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law.  If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions.
+
+When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it.  (Additional permissions may be written to require their own removal in certain cases when you modify the work.)  You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission.
+
+Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors.
+
+All other non-permissive additional terms are considered "further restrictions" within the meaning of section 10.  If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term.  If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying.
+
+If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms.
+
+Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way.
+
+8. Termination.
+
+You may not propagate or modify a covered work except as expressly provided under this License.  Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11).
+
+However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.
+
+Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License.  If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10.
+
+9. Acceptance Not Required for Having Copies.
+
+You are not required to accept this License in order to receive or run a copy of the Program.  Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance.  However, nothing other than this License grants you permission to propagate or modify any covered work.  These actions infringe copyright if you do not accept this License.  Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so.
+
+10. Automatic Licensing of Downstream Recipients.
+
+Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License.  You are not responsible for enforcing compliance by third parties with this License.
+
+An "entity transaction" is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations.  If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party's predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts.
+
+You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License.  For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it.
+
+11. Patents.
+
+A "contributor" is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based.  The work thus licensed is called the contributor's "contributor version".
+
+A contributor's "essential patent claims" are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version.  For purposes of this definition, "control" includes the right to grant patent sublicenses in a manner consistent with the requirements of this License.
+
+Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor's essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version.
+
+In the following three paragraphs, a "patent license" is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement).  To "grant" such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party.
+
+If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient's use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid.
+
+If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it.
+
+A patent license is "discriminatory" if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License.  You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007.
+
+Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law.
+
+12. No Surrender of Others' Freedom.
+
+If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License.  If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program.
+
+13. Remote Network Interaction; Use with the GNU General Public License.
+
+Notwithstanding any other provision of this License, if you modify the Program, your modified version must prominently offer all users interacting with it remotely through a computer network (if your version supports such interaction) an opportunity to receive the Corresponding Source of your version by providing access to the Corresponding Source from a network server at no charge, through some standard or customary means of facilitating copying of software.  This Corresponding Source shall include the Corresponding Source for any work covered by version 3 of the GNU General Public License that is incorporated pursuant to the following paragraph.
+
+Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU General Public License into a single combined work, and to convey the resulting work.  The terms of this License will continue to apply to the part which is the covered work, but the work with which it is combined will remain governed by version 3 of the GNU General Public License.
+
+14. Revised Versions of this License.
+
+The Free Software Foundation may publish revised and/or new versions of the GNU Affero General Public License from time to time.  Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program specifies that a certain numbered version of the GNU Affero General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation.  If the Program does not specify a version number of the GNU Affero General Public License, you may choose any version ever published by the Free Software Foundation.
+
+If the Program specifies that a proxy can decide which future versions of the GNU Affero General Public License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Program.
+
+Later license versions may give you additional or different permissions.  However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version.
+
+15. Disclaimer of Warranty.
+
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. Limitation of Liability.
+
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+17. Interpretation of Sections 15 and 16.
+
+If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee.
+
+END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program.  It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+     <one line to give the program's name and a brief idea of what it does.>
+     Copyright (C) <year>  <name of author>
+
+     This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+
+     You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If your software can interact with users remotely through a computer network, you should also make sure that it provides a way for users to get its source.  For example, if your program is a web application, its interface could display a "Source" link that leads users to an archive of the code.  There are many ways you could offer source, and different solutions will be better for different programs; see section 13 for the specific requirements.
+
+You should also get your employer (if you work as a programmer) or school, if any, to sign a "copyright disclaimer" for the program, if necessary. For more information on this, and how to apply and follow the GNU AGPL, see <http://www.gnu.org/licenses/>.

--- a/gmtsar/python/license_texts/GPL-2.0.txt
+++ b/gmtsar/python/license_texts/GPL-2.0.txt
@@ -1,0 +1,338 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/gmtsar/python/license_texts/LGPL-2.1.txt
+++ b/gmtsar/python/license_texts/LGPL-2.1.txt
@@ -1,0 +1,501 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1990
+  Moe Ghoul, President of Vice
+
+That's all there is to it!

--- a/gmtsar/python/license_texts/LGPL-3.0.txt
+++ b/gmtsar/python/license_texts/LGPL-3.0.txt
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/gmtsar/python/license_texts/MPL-1.1.txt
+++ b/gmtsar/python/license_texts/MPL-1.1.txt
@@ -1,0 +1,469 @@
+                          MOZILLA PUBLIC LICENSE
+                                Version 1.1
+
+                              ---------------
+
+1. Definitions.
+
+     1.0.1. "Commercial Use" means distribution or otherwise making the
+     Covered Code available to a third party.
+
+     1.1. "Contributor" means each entity that creates or contributes to
+     the creation of Modifications.
+
+     1.2. "Contributor Version" means the combination of the Original
+     Code, prior Modifications used by a Contributor, and the Modifications
+     made by that particular Contributor.
+
+     1.3. "Covered Code" means the Original Code or Modifications or the
+     combination of the Original Code and Modifications, in each case
+     including portions thereof.
+
+     1.4. "Electronic Distribution Mechanism" means a mechanism generally
+     accepted in the software development community for the electronic
+     transfer of data.
+
+     1.5. "Executable" means Covered Code in any form other than Source
+     Code.
+
+     1.6. "Initial Developer" means the individual or entity identified
+     as the Initial Developer in the Source Code notice required by Exhibit
+     A.
+
+     1.7. "Larger Work" means a work which combines Covered Code or
+     portions thereof with code not governed by the terms of this License.
+
+     1.8. "License" means this document.
+
+     1.8.1. "Licensable" means having the right to grant, to the maximum
+     extent possible, whether at the time of the initial grant or
+     subsequently acquired, any and all of the rights conveyed herein.
+
+     1.9. "Modifications" means any addition to or deletion from the
+     substance or structure of either the Original Code or any previous
+     Modifications. When Covered Code is released as a series of files, a
+     Modification is:
+          A. Any addition to or deletion from the contents of a file
+          containing Original Code or previous Modifications.
+
+          B. Any new file that contains any part of the Original Code or
+          previous Modifications.
+
+     1.10. "Original Code" means Source Code of computer software code
+     which is described in the Source Code notice required by Exhibit A as
+     Original Code, and which, at the time of its release under this
+     License is not already Covered Code governed by this License.
+
+     1.10.1. "Patent Claims" means any patent claim(s), now owned or
+     hereafter acquired, including without limitation,  method, process,
+     and apparatus claims, in any patent Licensable by grantor.
+
+     1.11. "Source Code" means the preferred form of the Covered Code for
+     making modifications to it, including all modules it contains, plus
+     any associated interface definition files, scripts used to control
+     compilation and installation of an Executable, or source code
+     differential comparisons against either the Original Code or another
+     well known, available Covered Code of the Contributor's choice. The
+     Source Code can be in a compressed or archival form, provided the
+     appropriate decompression or de-archiving software is widely available
+     for no charge.
+
+     1.12. "You" (or "Your")  means an individual or a legal entity
+     exercising rights under, and complying with all of the terms of, this
+     License or a future version of this License issued under Section 6.1.
+     For legal entities, "You" includes any entity which controls, is
+     controlled by, or is under common control with You. For purposes of
+     this definition, "control" means (a) the power, direct or indirect,
+     to cause the direction or management of such entity, whether by
+     contract or otherwise, or (b) ownership of more than fifty percent
+     (50%) of the outstanding shares or beneficial ownership of such
+     entity.
+
+2. Source Code License.
+
+     2.1. The Initial Developer Grant.
+     The Initial Developer hereby grants You a world-wide, royalty-free,
+     non-exclusive license, subject to third party intellectual property
+     claims:
+          (a)  under intellectual property rights (other than patent or
+          trademark) Licensable by Initial Developer to use, reproduce,
+          modify, display, perform, sublicense and distribute the Original
+          Code (or portions thereof) with or without Modifications, and/or
+          as part of a Larger Work; and
+
+          (b) under Patents Claims infringed by the making, using or
+          selling of Original Code, to make, have made, use, practice,
+          sell, and offer for sale, and/or otherwise dispose of the
+          Original Code (or portions thereof).
+
+          (c) the licenses granted in this Section 2.1(a) and (b) are
+          effective on the date Initial Developer first distributes
+          Original Code under the terms of this License.
+
+          (d) Notwithstanding Section 2.1(b) above, no patent license is
+          granted: 1) for code that You delete from the Original Code; 2)
+          separate from the Original Code;  or 3) for infringements caused
+          by: i) the modification of the Original Code or ii) the
+          combination of the Original Code with other software or devices.
+
+     2.2. Contributor Grant.
+     Subject to third party intellectual property claims, each Contributor
+     hereby grants You a world-wide, royalty-free, non-exclusive license
+
+          (a)  under intellectual property rights (other than patent or
+          trademark) Licensable by Contributor, to use, reproduce, modify,
+          display, perform, sublicense and distribute the Modifications
+          created by such Contributor (or portions thereof) either on an
+          unmodified basis, with other Modifications, as Covered Code
+          and/or as part of a Larger Work; and
+
+          (b) under Patent Claims infringed by the making, using, or
+          selling of  Modifications made by that Contributor either alone
+          and/or in combination with its Contributor Version (or portions
+          of such combination), to make, use, sell, offer for sale, have
+          made, and/or otherwise dispose of: 1) Modifications made by that
+          Contributor (or portions thereof); and 2) the combination of
+          Modifications made by that Contributor with its Contributor
+          Version (or portions of such combination).
+
+          (c) the licenses granted in Sections 2.2(a) and 2.2(b) are
+          effective on the date Contributor first makes Commercial Use of
+          the Covered Code.
+
+          (d)    Notwithstanding Section 2.2(b) above, no patent license is
+          granted: 1) for any code that Contributor has deleted from the
+          Contributor Version; 2)  separate from the Contributor Version;
+          3)  for infringements caused by: i) third party modifications of
+          Contributor Version or ii)  the combination of Modifications made
+          by that Contributor with other software  (except as part of the
+          Contributor Version) or other devices; or 4) under Patent Claims
+          infringed by Covered Code in the absence of Modifications made by
+          that Contributor.
+
+3. Distribution Obligations.
+
+     3.1. Application of License.
+     The Modifications which You create or to which You contribute are
+     governed by the terms of this License, including without limitation
+     Section 2.2. The Source Code version of Covered Code may be
+     distributed only under the terms of this License or a future version
+     of this License released under Section 6.1, and You must include a
+     copy of this License with every copy of the Source Code You
+     distribute. You may not offer or impose any terms on any Source Code
+     version that alters or restricts the applicable version of this
+     License or the recipients' rights hereunder. However, You may include
+     an additional document offering the additional rights described in
+     Section 3.5.
+
+     3.2. Availability of Source Code.
+     Any Modification which You create or to which You contribute must be
+     made available in Source Code form under the terms of this License
+     either on the same media as an Executable version or via an accepted
+     Electronic Distribution Mechanism to anyone to whom you made an
+     Executable version available; and if made available via Electronic
+     Distribution Mechanism, must remain available for at least twelve (12)
+     months after the date it initially became available, or at least six
+     (6) months after a subsequent version of that particular Modification
+     has been made available to such recipients. You are responsible for
+     ensuring that the Source Code version remains available even if the
+     Electronic Distribution Mechanism is maintained by a third party.
+
+     3.3. Description of Modifications.
+     You must cause all Covered Code to which You contribute to contain a
+     file documenting the changes You made to create that Covered Code and
+     the date of any change. You must include a prominent statement that
+     the Modification is derived, directly or indirectly, from Original
+     Code provided by the Initial Developer and including the name of the
+     Initial Developer in (a) the Source Code, and (b) in any notice in an
+     Executable version or related documentation in which You describe the
+     origin or ownership of the Covered Code.
+
+     3.4. Intellectual Property Matters
+          (a) Third Party Claims.
+          If Contributor has knowledge that a license under a third party's
+          intellectual property rights is required to exercise the rights
+          granted by such Contributor under Sections 2.1 or 2.2,
+          Contributor must include a text file with the Source Code
+          distribution titled "LEGAL" which describes the claim and the
+          party making the claim in sufficient detail that a recipient will
+          know whom to contact. If Contributor obtains such knowledge after
+          the Modification is made available as described in Section 3.2,
+          Contributor shall promptly modify the LEGAL file in all copies
+          Contributor makes available thereafter and shall take other steps
+          (such as notifying appropriate mailing lists or newsgroups)
+          reasonably calculated to inform those who received the Covered
+          Code that new knowledge has been obtained.
+
+          (b) Contributor APIs.
+          If Contributor's Modifications include an application programming
+          interface and Contributor has knowledge of patent licenses which
+          are reasonably necessary to implement that API, Contributor must
+          also include this information in the LEGAL file.
+
+               (c)    Representations.
+          Contributor represents that, except as disclosed pursuant to
+          Section 3.4(a) above, Contributor believes that Contributor's
+          Modifications are Contributor's original creation(s) and/or
+          Contributor has sufficient rights to grant the rights conveyed by
+          this License.
+
+     3.5. Required Notices.
+     You must duplicate the notice in Exhibit A in each file of the Source
+     Code.  If it is not possible to put such notice in a particular Source
+     Code file due to its structure, then You must include such notice in a
+     location (such as a relevant directory) where a user would be likely
+     to look for such a notice.  If You created one or more Modification(s)
+     You may add your name as a Contributor to the notice described in
+     Exhibit A.  You must also duplicate this License in any documentation
+     for the Source Code where You describe recipients' rights or ownership
+     rights relating to Covered Code.  You may choose to offer, and to
+     charge a fee for, warranty, support, indemnity or liability
+     obligations to one or more recipients of Covered Code. However, You
+     may do so only on Your own behalf, and not on behalf of the Initial
+     Developer or any Contributor. You must make it absolutely clear than
+     any such warranty, support, indemnity or liability obligation is
+     offered by You alone, and You hereby agree to indemnify the Initial
+     Developer and every Contributor for any liability incurred by the
+     Initial Developer or such Contributor as a result of warranty,
+     support, indemnity or liability terms You offer.
+
+     3.6. Distribution of Executable Versions.
+     You may distribute Covered Code in Executable form only if the
+     requirements of Section 3.1-3.5 have been met for that Covered Code,
+     and if You include a notice stating that the Source Code version of
+     the Covered Code is available under the terms of this License,
+     including a description of how and where You have fulfilled the
+     obligations of Section 3.2. The notice must be conspicuously included
+     in any notice in an Executable version, related documentation or
+     collateral in which You describe recipients' rights relating to the
+     Covered Code. You may distribute the Executable version of Covered
+     Code or ownership rights under a license of Your choice, which may
+     contain terms different from this License, provided that You are in
+     compliance with the terms of this License and that the license for the
+     Executable version does not attempt to limit or alter the recipient's
+     rights in the Source Code version from the rights set forth in this
+     License. If You distribute the Executable version under a different
+     license You must make it absolutely clear that any terms which differ
+     from this License are offered by You alone, not by the Initial
+     Developer or any Contributor. You hereby agree to indemnify the
+     Initial Developer and every Contributor for any liability incurred by
+     the Initial Developer or such Contributor as a result of any such
+     terms You offer.
+
+     3.7. Larger Works.
+     You may create a Larger Work by combining Covered Code with other code
+     not governed by the terms of this License and distribute the Larger
+     Work as a single product. In such a case, You must make sure the
+     requirements of this License are fulfilled for the Covered Code.
+
+4. Inability to Comply Due to Statute or Regulation.
+
+     If it is impossible for You to comply with any of the terms of this
+     License with respect to some or all of the Covered Code due to
+     statute, judicial order, or regulation then You must: (a) comply with
+     the terms of this License to the maximum extent possible; and (b)
+     describe the limitations and the code they affect. Such description
+     must be included in the LEGAL file described in Section 3.4 and must
+     be included with all distributions of the Source Code. Except to the
+     extent prohibited by statute or regulation, such description must be
+     sufficiently detailed for a recipient of ordinary skill to be able to
+     understand it.
+
+5. Application of this License.
+
+     This License applies to code to which the Initial Developer has
+     attached the notice in Exhibit A and to related Covered Code.
+
+6. Versions of the License.
+
+     6.1. New Versions.
+     Netscape Communications Corporation ("Netscape") may publish revised
+     and/or new versions of the License from time to time. Each version
+     will be given a distinguishing version number.
+
+     6.2. Effect of New Versions.
+     Once Covered Code has been published under a particular version of the
+     License, You may always continue to use it under the terms of that
+     version. You may also choose to use such Covered Code under the terms
+     of any subsequent version of the License published by Netscape. No one
+     other than Netscape has the right to modify the terms applicable to
+     Covered Code created under this License.
+
+     6.3. Derivative Works.
+     If You create or use a modified version of this License (which you may
+     only do in order to apply it to code which is not already Covered Code
+     governed by this License), You must (a) rename Your license so that
+     the phrases "Mozilla", "MOZILLAPL", "MOZPL", "Netscape",
+     "MPL", "NPL" or any confusingly similar phrase do not appear in your
+     license (except to note that your license differs from this License)
+     and (b) otherwise make it clear that Your version of the license
+     contains terms which differ from the Mozilla Public License and
+     Netscape Public License. (Filling in the name of the Initial
+     Developer, Original Code or Contributor in the notice described in
+     Exhibit A shall not of themselves be deemed to be modifications of
+     this License.)
+
+7. DISCLAIMER OF WARRANTY.
+
+     COVERED CODE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS" BASIS,
+     WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING,
+     WITHOUT LIMITATION, WARRANTIES THAT THE COVERED CODE IS FREE OF
+     DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING.
+     THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED CODE
+     IS WITH YOU. SHOULD ANY COVERED CODE PROVE DEFECTIVE IN ANY RESPECT,
+     YOU (NOT THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE
+     COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER
+     OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF
+     ANY COVERED CODE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
+
+8. TERMINATION.
+
+     8.1.  This License and the rights granted hereunder will terminate
+     automatically if You fail to comply with terms herein and fail to cure
+     such breach within 30 days of becoming aware of the breach. All
+     sublicenses to the Covered Code which are properly granted shall
+     survive any termination of this License. Provisions which, by their
+     nature, must remain in effect beyond the termination of this License
+     shall survive.
+
+     8.2.  If You initiate litigation by asserting a patent infringement
+     claim (excluding declatory judgment actions) against Initial Developer
+     or a Contributor (the Initial Developer or Contributor against whom
+     You file such action is referred to as "Participant")  alleging that:
+
+     (a)  such Participant's Contributor Version directly or indirectly
+     infringes any patent, then any and all rights granted by such
+     Participant to You under Sections 2.1 and/or 2.2 of this License
+     shall, upon 60 days notice from Participant terminate prospectively,
+     unless if within 60 days after receipt of notice You either: (i)
+     agree in writing to pay Participant a mutually agreeable reasonable
+     royalty for Your past and future use of Modifications made by such
+     Participant, or (ii) withdraw Your litigation claim with respect to
+     the Contributor Version against such Participant.  If within 60 days
+     of notice, a reasonable royalty and payment arrangement are not
+     mutually agreed upon in writing by the parties or the litigation claim
+     is not withdrawn, the rights granted by Participant to You under
+     Sections 2.1 and/or 2.2 automatically terminate at the expiration of
+     the 60 day notice period specified above.
+
+     (b)  any software, hardware, or device, other than such Participant's
+     Contributor Version, directly or indirectly infringes any patent, then
+     any rights granted to You by such Participant under Sections 2.1(b)
+     and 2.2(b) are revoked effective as of the date You first made, used,
+     sold, distributed, or had made, Modifications made by that
+     Participant.
+
+     8.3.  If You assert a patent infringement claim against Participant
+     alleging that such Participant's Contributor Version directly or
+     indirectly infringes any patent where such claim is resolved (such as
+     by license or settlement) prior to the initiation of patent
+     infringement litigation, then the reasonable value of the licenses
+     granted by such Participant under Sections 2.1 or 2.2 shall be taken
+     into account in determining the amount or value of any payment or
+     license.
+
+     8.4.  In the event of termination under Sections 8.1 or 8.2 above,
+     all end user license agreements (excluding distributors and resellers)
+     which have been validly granted by You or any distributor hereunder
+     prior to termination shall survive termination.
+
+9. LIMITATION OF LIABILITY.
+
+     UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT
+     (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE INITIAL
+     DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF COVERED CODE,
+     OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR
+     ANY INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY
+     CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL,
+     WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER
+     COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN
+     INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF
+     LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY
+     RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT APPLICABLE LAW
+     PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE
+     EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO
+     THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
+
+10. U.S. GOVERNMENT END USERS.
+
+     The Covered Code is a "commercial item," as that term is defined in
+     48 C.F.R. 2.101 (Oct. 1995), consisting of "commercial computer
+     software" and "commercial computer software documentation," as such
+     terms are used in 48 C.F.R. 12.212 (Sept. 1995). Consistent with 48
+     C.F.R. 12.212 and 48 C.F.R. 227.7202-1 through 227.7202-4 (June 1995),
+     all U.S. Government End Users acquire Covered Code with only those
+     rights set forth herein.
+
+11. MISCELLANEOUS.
+
+     This License represents the complete agreement concerning subject
+     matter hereof. If any provision of this License is held to be
+     unenforceable, such provision shall be reformed only to the extent
+     necessary to make it enforceable. This License shall be governed by
+     California law provisions (except to the extent applicable law, if
+     any, provides otherwise), excluding its conflict-of-law provisions.
+     With respect to disputes in which at least one party is a citizen of,
+     or an entity chartered or registered to do business in the United
+     States of America, any litigation relating to this License shall be
+     subject to the jurisdiction of the Federal Courts of the Northern
+     District of California, with venue lying in Santa Clara County,
+     California, with the losing party responsible for costs, including
+     without limitation, court costs and reasonable attorneys' fees and
+     expenses. The application of the United Nations Convention on
+     Contracts for the International Sale of Goods is expressly excluded.
+     Any law or regulation which provides that the language of a contract
+     shall be construed against the drafter shall not apply to this
+     License.
+
+12. RESPONSIBILITY FOR CLAIMS.
+
+     As between Initial Developer and the Contributors, each party is
+     responsible for claims and damages arising, directly or indirectly,
+     out of its utilization of rights under this License and You agree to
+     work with Initial Developer and Contributors to distribute such
+     responsibility on an equitable basis. Nothing herein is intended or
+     shall be deemed to constitute any admission of liability.
+
+13. MULTIPLE-LICENSED CODE.
+
+     Initial Developer may designate portions of the Covered Code as
+     "Multiple-Licensed".  "Multiple-Licensed" means that the Initial
+     Developer permits you to utilize portions of the Covered Code under
+     Your choice of the MPL or the alternative licenses, if any, specified
+     by the Initial Developer in the file described in Exhibit A.
+
+EXHIBIT A -Mozilla Public License.
+
+     ``The contents of this file are subject to the Mozilla Public License
+     Version 1.1 (the "License"); you may not use this file except in
+     compliance with the License. You may obtain a copy of the License at
+     https://www.mozilla.org/MPL/
+
+     Software distributed under the License is distributed on an "AS IS"
+     basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+     License for the specific language governing rights and limitations
+     under the License.
+
+     The Original Code is ______________________________________.
+
+     The Initial Developer of the Original Code is ________________________.
+     Portions created by ______________________ are Copyright (C) ______
+     _______________________. All Rights Reserved.
+
+     Contributor(s): ______________________________________.
+
+     Alternatively, the contents of this file may be used under the terms
+     of the _____ license (the  "[___] License"), in which case the
+     provisions of [______] License are applicable instead of those
+     above.  If you wish to allow use of your version of this file only
+     under the terms of the [____] License and not to allow others to use
+     your version of this file under the MPL, indicate your decision by
+     deleting  the provisions above and replace  them with the notice and
+     other provisions required by the [___] License.  If you do not delete
+     the provisions above, a recipient may use your version of this file
+     under either the MPL or the [___] License."
+
+     [NOTE: The text of this Exhibit A may differ slightly from the text of
+     the notices in the Source Code files of the Original Code. You should
+     use the text of this Exhibit A rather than the text found in the
+     Original Code Source Code for Your Modifications.]

--- a/gmtsar/python/license_texts/MPL-2.0.txt
+++ b/gmtsar/python/license_texts/MPL-2.0.txt
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/gmtsar/python/requirements.txt
+++ b/gmtsar/python/requirements.txt
@@ -3,13 +3,30 @@
 # tagged release if exact reproducibility is required.
 #
 # Pip-installable:
-numpy<2
+numpy>=2         # confirmed working 2026-07-23 via a genuine clean-room test:
+                 # fresh env, numpy 2.4.6, full bin_py/tests/ suite (562
+                 # passed/59 skipped/0 failed) INCLUDING the real C-vs-Python
+                 # xcorr parity test against real data -- bit/float-exact,
+                 # no numerical drift. Both Cython extensions
+                 # (build_surface_kernel.py, snaphu_py's build script)
+                 # rebuild cleanly against numpy2 headers. Previously pinned
+                 # <2 with no documented reason; raised after a real
+                 # external report (InSARHub, a downstream consumer, wants
+                 # numpy>=2 for its own dependencies) prompted actually
+                 # testing it instead of assuming.
 scipy>=1.10
 scikit-image>=0.19
 matplotlib>=3.5
 xarray>=2022.11
 netCDF4>=1.6
-numba>=0.56      # JIT kernels: xcorr_py, resamp_py, SAT JIT path, snaphu_py
+numba>=0.60      # JIT kernels: xcorr_py, resamp_py, SAT JIT path, snaphu_py.
+                 # Floor raised from >=0.56 (2026-07-23): numba<0.60 caps
+                 # numpy far below 2.0 in its own PyPI metadata (0.56.4:
+                 # numpy<1.24; 0.59.x: numpy<1.27) -- doesn't bite today
+                 # since pip's resolver picks a modern numba anyway with no
+                 # other cap forcing it low, but an offline/locked install
+                 # pinning numba<0.60 alongside numpy>=2 would fail outright.
+                 # numba only gained real numpy 2.x ABI support at 0.60.0.
 cython>=3.0      # builds utils/_surface_kernel (gmt_surface_py default-ON path)
 h5py>=3.0        # make_slc_nsr_py (GMTSAR_NSR_PREPROC_PY, default ON since 2026-07-13) — reads NISAR RSLC HDF5
 pytest>=7.0      # runs bin_py/tests/ (2026-07-14: a fresh --system conda

--- a/gmtsar/python/tests/case_runner.py
+++ b/gmtsar/python/tests/case_runner.py
@@ -27,6 +27,7 @@ import argparse
 import glob
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -36,7 +37,22 @@ from datetime import datetime, timezone
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, _HERE)
+sys.path.insert(0, os.path.join(_HERE, os.pardir, "utils"))
 from cases import CASES  # noqa: E402
+import gmtsar_lib as _gmtsar_lib  # noqa: E402
+
+
+def _run_script(args, **kwargs):
+    """subprocess.run() for a command whose argv[0] is an extensionless
+    shebang script (pop_config, cleanup, ...) staged into bin/, or an
+    explicit .csh file. Windows' CreateProcess can exec neither directly
+    (no shebang support, and a bare name only gets ".exe" auto-appended)
+    -- route through Git Bash via gmtsar_lib.shell_run() there, same as
+    the main pipeline does; plain subprocess.run() elsewhere."""
+    if os.name == 'nt':
+        cmd = ' '.join(shlex.quote(a) for a in args)
+        return _gmtsar_lib.shell_run(cmd, **kwargs)
+    return subprocess.run(args, **kwargs)
 
 
 def _repo_root() -> str:
@@ -155,7 +171,7 @@ def _stage_config(case: str, tree_dir: str, staged_config: str, topo_mode: int |
     elif topo_mode is not None and not os.path.exists(cfg_path):
         sat = CASES[case]["satellite"]
         with open(cfg_path, "w") as f:
-            subprocess.run(["pop_config", sat], cwd=tree_dir, env=env, check=True, stdout=f)
+            _run_script(["pop_config", sat], cwd=tree_dir, env=env, check=True, stdout=f)
     if topo_mode is not None and os.path.exists(cfg_path):
         _force_topo_interp_mode(cfg_path, topo_mode)
 
@@ -243,7 +259,7 @@ def _run_subprocess_env(preload_shim: str | None, gmtsar_bin: str | None,
     if repo_root:
         prefix.append(os.path.join(repo_root, "bin"))
     if prefix:
-        env["PATH"] = ":".join(prefix) + ":" + env.get("PATH", "")
+        env["PATH"] = os.pathsep.join(prefix) + os.pathsep + env.get("PATH", "")
     if profile:
         env["GMTSAR_PROFILE"] = "1"
         env["GMTSAR_PROFILE_CASE"] = case
@@ -260,10 +276,20 @@ def _run_recipe(tree_dir: str, case: str, env: dict) -> subprocess.CompletedProc
     `"./README_x.txt"` from inside bash, which silently falls back to
     /bin/sh on an ENOEXEC (POSIX "looks like a text script" convention).
     subprocess.run() does execve() directly with no such fallback, so we
-    invoke via bash explicitly instead of relying on it."""
+    invoke via bash explicitly instead of relying on it.
+
+    Resolves bash via gmtsar_lib._win_bash() rather than a bare "bash" on
+    Windows: a plain ["bash", ...] trusts PATH order, and Windows 10+
+    ships a System32\\bash.exe stub that launches WSL -- if that resolves
+    first, the recipe silently runs against a WSL prompt ("Windows
+    Subsystem for Linux has no installed distributions...") instead of
+    Git Bash. Real bug hit standing this up: both the ref and new trees'
+    entire recipe runs no-opped against that WSL stub with zero real
+    pipeline output, while case_runner.py still reported success."""
+    bash = _gmtsar_lib._win_bash() if os.name == 'nt' else 'bash'
     log_path = os.path.join(tree_dir, "log.txt")
     with open(log_path, "w") as logf:
-        return subprocess.run(["bash", f"README_{case}.txt"], cwd=tree_dir, env=env,
+        return subprocess.run([bash, f"README_{case}.txt"], cwd=tree_dir, env=env,
                                stdout=logf, stderr=subprocess.STDOUT)
 
 
@@ -320,7 +346,7 @@ def run_case(case: str, csh_dir: str, py_dir: str, tarball: str, py_readme: str,
         if topo_mode_ab:
             # Mode-AB "baseline" slot: run the Python recipe (not csh) into
             # csh_dir, forced to topo_interp_mode=0.
-            subprocess.run(["cleanup", "all"], cwd=csh_dir, env=env)
+            _run_script(["cleanup", "all"], cwd=csh_dir, env=env)
             shutil.copy(py_readme, os.path.join(csh_dir, os.path.basename(py_readme)))
             readme_path = os.path.join(csh_dir, os.path.basename(py_readme))
             os.chmod(readme_path, 0o755)
@@ -364,7 +390,7 @@ def run_case(case: str, csh_dir: str, py_dir: str, tarball: str, py_readme: str,
             _check_config_drift(case, bundled_cfg, staged_config)
 
         t0 = time.time()
-        subprocess.run(["cleanup", "all"], cwd=py_dir, env=env)
+        _run_script(["cleanup", "all"], cwd=py_dir, env=env)
         readme_path = os.path.join(py_dir, os.path.basename(py_readme))
         shutil.copy(py_readme, readme_path)
         os.chmod(readme_path, 0o755)

--- a/gmtsar/python/tests/cases.py
+++ b/gmtsar/python/tests/cases.py
@@ -25,13 +25,13 @@ else:
 # get the Python recipe, no csh at all (see case_runner.sh). Named ref_test/
 # new_test in that mode so the folders aren't misleadingly labeled "csh".
 if os.environ.get('TOPO_MODE_AB') == '1':
-    cshRefRoot    = workAbsoluteDir + 'ref_test/'      # mode=0 (baseline)
-    pythonRunRoot = workAbsoluteDir + 'new_test/'       # mode=1 (variant)
+    cshRefRoot    = workAbsoluteDir + 'ref_test' + os.sep      # mode=0 (baseline)
+    pythonRunRoot = workAbsoluteDir + 'new_test' + os.sep       # mode=1 (variant)
 else:
-    pythonRunRoot = workAbsoluteDir + 'python_test/'   # Python-framework outputs
-    cshRefRoot    = workAbsoluteDir + 'csh_test/'      # legacy csh reference outputs
-datasetRoot   = workAbsoluteDir + 'dataset/'       # downloaded raw tarballs
-recipesDir    = workAbsoluteDir + 'recipes/'
+    pythonRunRoot = workAbsoluteDir + 'python_test' + os.sep   # Python-framework outputs
+    cshRefRoot    = workAbsoluteDir + 'csh_test' + os.sep      # legacy csh reference outputs
+datasetRoot   = workAbsoluteDir + 'dataset' + os.sep       # downloaded raw tarballs
+recipesDir    = workAbsoluteDir + 'recipes' + os.sep
 
 # Frozen csh reference (gitignored, ~5.8 GB). When present, compare.py runs
 # three pairs per file: py-vs-csh, csh-vs-frozen, py-vs-frozen.

--- a/gmtsar/python/tests/sweep.py
+++ b/gmtsar/python/tests/sweep.py
@@ -252,7 +252,7 @@ def main():
 
     gmtsar = _derive_gmtsar()
     os.environ["GMTSAR"] = gmtsar
-    os.environ["PATH"] = os.path.join(gmtsar, "bin") + ":" + os.environ.get("PATH", "")
+    os.environ["PATH"] = os.path.join(gmtsar, "bin") + os.pathsep + os.environ.get("PATH", "")
     if not shutil.which("python3"):
         print("sweep.py: python3 not on PATH — activate conda env or set PATH", file=sys.stderr)
         sys.exit(1)
@@ -331,11 +331,19 @@ def main():
 
     # Kick off a background download for every case. Reuses an already-
     # complete/partial file via `wget -c` semantics (resume, or near-instant
-    # HEAD-only check if already complete).
+    # HEAD-only check if already complete). wget isn't present on a bare
+    # native-Windows/conda install (no apt, and it's not in the
+    # WINDOWS_CONDA_BOOTSTRAP_PACKAGES set) -- fall back to curl, which
+    # ships with Git for Windows and modern Windows itself; `-C -` is
+    # curl's equivalent resume-or-redownload flag to wget's `-c`.
+    if shutil.which("wget"):
+        dl_cmd = lambda c: ["wget", "-c", "-q", "--timeout=60", "--tries=3", url[c], "-O", tarball[c]]
+    else:
+        dl_cmd = lambda c: ["curl", "-s", "-C", "-", "--connect-timeout", "60",
+                             "--retry", "3", "-L", url[c], "-o", tarball[c]]
     dl_procs: dict[str, subprocess.Popen] = {}
     for c in cases:
-        dl_procs[c] = subprocess.Popen(
-            ["wget", "-c", "-q", "--timeout=60", "--tries=3", url[c], "-O", tarball[c]])
+        dl_procs[c] = subprocess.Popen(dl_cmd(c))
         _log_line(log_path, f"DOWNLOAD start (background) {c}")
 
     preload_shim = os.path.abspath(os.path.join(tests_dir, os.pardir, "fftw_force_serial.so"))

--- a/gmtsar/python/tests/test_install.py
+++ b/gmtsar/python/tests/test_install.py
@@ -270,8 +270,16 @@ def _locate_fresh_conda_prefix(conda_env: str) -> Path | None:
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument("--system", choices=["ubuntu", "conda"], required=True,
-                    help="passed straight to install.py --system")
+    p.add_argument("--system", choices=["ubuntu", "conda", "conda-linux-full"], required=True,
+                    help="passed straight to install.py --system. "
+                         "conda-windows-full deliberately not included -- this "
+                         "script is POSIX-only throughout (hardcoded "
+                         "python3, /bin/ paths, gmtsar_sharedir.csh "
+                         "invoked directly), and conda-windows-full's conda env "
+                         "layout differs entirely (prefix/python.exe, not "
+                         "prefix/bin/python3) -- adding it to --choices "
+                         "without also fixing those would silently pretend "
+                         "coverage that isn't real.")
     mode = p.add_mutually_exclusive_group()
     mode.add_argument("--smoke", action="store_true",
                        help="(default) fresh install + gmtsar_sharedir.csh "
@@ -325,7 +333,7 @@ def main() -> int:
 
     install_cmd = ["python3", str(clone_python_dir / "install.py"),
                    "--system", args.system]
-    if args.system == "conda":
+    if args.system in ("conda", "conda-linux-full"):
         install_cmd += ["--conda-env", conda_env]
     ok, dt = _run(install_cmd, "install", cwd=str(clone_python_dir))
     results.append(("install.py --system " + args.system, ok, dt))
@@ -340,7 +348,7 @@ def main() -> int:
     env["GMTSAR"] = str(clone_dir)
     env["PATH"] = f"{clone_dir}/bin:{env.get('PATH', '')}"
     py_exe = "python3"
-    if args.system == "conda":
+    if args.system in ("conda", "conda-linux-full"):
         prefix = _locate_fresh_conda_prefix(conda_env)
         if prefix is not None:
             env["PATH"] = f"{prefix}/bin:{env['PATH']}"

--- a/gmtsar/python/utils/filter
+++ b/gmtsar/python/utils/filter
@@ -70,8 +70,12 @@ def filter():
     print('FILTER: define filter and decimation variables ... ...')
     
     # Resolve sharedir dynamically (works for any install prefix — this fork
-    # installs to $REPO_ROOT/share/gmtsar, not /usr/local).
-    sharedir = subprocess.run(['gmtsar_sharedir.csh'], capture_output=True, text=True).stdout.strip()
+    # installs to $REPO_ROOT/share/gmtsar, not /usr/local). Uses
+    # resolve_sharedir() directly rather than shelling out to
+    # gmtsar_sharedir.csh: that's an extensionless/.csh script Windows'
+    # CreateProcess can't exec without going through bash, and
+    # resolve_sharedir() does the identical lookup in-process anyway.
+    sharedir = resolve_sharedir()
     filter3  = sharedir + '/filters/fill.3x3'
     filter4  = sharedir + '/filters/xdir'
     filter5  = sharedir + '/filters/ydir'

--- a/gmtsar/python/utils/gmtsar_lib.py
+++ b/gmtsar/python/utils/gmtsar_lib.py
@@ -11,25 +11,147 @@
 """
 
 import sys, os, re, configparser
-import subprocess, glob
+import subprocess, glob, shutil, threading
+
+_WIN_BASH = None
+_WIN_BASH_RESOLVED = False
+_WIN_BASH_LOCK = threading.Lock()
+
+
+def _win_bash():
+    """Locate Git-for-Windows' bash.exe (memoized). subprocess's shell=True
+    invokes cmd.exe on Windows, which understands none of the POSIX shell
+    syntax (&&, ln -sf, rm -rf, mkdir -p, backticks, pipes to /dev/null,
+    ...) used throughout this pipeline -- Git Bash (near-universally
+    present alongside a Windows git install, and this repo already
+    requires git) provides a real POSIX shell without needing WSL/sudo."""
+    global _WIN_BASH, _WIN_BASH_RESOLVED
+    if _WIN_BASH_RESOLVED:
+        return _WIN_BASH
+    with _WIN_BASH_LOCK:
+        # Re-check inside the lock: another thread may have finished
+        # resolving while this one was waiting on the lock. Without the
+        # lock (and with the old code's _WIN_BASH_RESOLVED=True set
+        # BEFORE _WIN_BASH itself was assigned), two threads racing here
+        # -- as case_runner.py's csh_slot()/py_slot() do -- could see
+        # _WIN_BASH_RESOLVED already True but _WIN_BASH still None,
+        # silently falling through shell_run() to its shell=True/cmd.exe
+        # fallback instead of Git Bash. Real bug hit standing this up:
+        # one of two concurrent `cleanup all` calls failed with cmd.exe's
+        # "'cleanup' is not recognized ..." while the other succeeded.
+        if _WIN_BASH_RESOLVED:
+            return _WIN_BASH
+        if os.name == 'nt':
+            path_bash = shutil.which('bash')
+            # Windows 10+ ships a System32\bash.exe stub that launches WSL --
+            # NOT a real shell (this project is native-Windows-only, no WSL),
+            # and it'd otherwise shadow Git Bash whenever System32 precedes
+            # Git\bin on PATH. Reject it explicitly rather than trusting
+            # PATH order.
+            if path_bash and 'system32' in path_bash.lower():
+                path_bash = None
+            for candidate in (
+                os.environ.get('GMTSAR_WIN_BASH'),
+                r'C:\Program Files\Git\bin\bash.exe',
+                r'C:\Program Files (x86)\Git\bin\bash.exe',
+                path_bash,
+            ):
+                if candidate and os.path.isfile(candidate):
+                    _WIN_BASH = candidate
+                    break
+            else:
+                sys.exit(
+                    "gmtsar_lib: running on Windows but no Git-for-Windows "
+                    "bash.exe found (checked $GMTSAR_WIN_BASH, PATH, "
+                    "C:\\Program Files\\Git\\bin\\bash.exe) -- this pipeline "
+                    "shells out using POSIX syntax (ln -sf, rm -rf, mkdir -p, "
+                    "&&) that cmd.exe cannot run. Install Git for Windows, or "
+                    "set GMTSAR_WIN_BASH to a bash.exe path.")
+        _WIN_BASH_RESOLVED = True
+    return _WIN_BASH
+
+
+_WIN_PATH_VAR = 'GMTSAR_WIN_PATH'
+# Carries the pristine Windows-style PATH through nested bash/python hops
+# (p2p_processing -> bash -c 'pre_proc ...' -> pre_proc.py -> bash -c
+# 'extend_orbit ...' -> ...), as a defensive fallback only -- see
+# _bash_env(). Deliberately NOT used to convert PATH to POSIX/MSYS form:
+# an earlier version of this function did exactly that (rewriting each
+# entry to /c/... form for bash's own env=), which seemed right (bash's
+# *own* command lookup does need a POSIX-style PATH) but broke every
+# single gmtsar .exe launched from within that bash -- confirmed via a
+# direct CreateProcess repro (bypassing bash entirely) that returned
+# 0xC0000135 / STATUS_DLL_NOT_FOUND with a POSIX PATH and rc=0 with a
+# Windows-style one. Reason: those .exes dynamically link gmt.dll /
+# openblas.dll / tiff.dll from the conda env's Library/bin, and the
+# WINDOWS PE LOADER (not bash) resolves that at process-create time --
+# it cannot parse a colon-separated /c/... PATH at all. Git Bash/MSYS
+# already handles the POSIX-view-internally / Windows-view-to-children
+# duality correctly on its own (that's why the ORIGINAL, unmodified
+# gmtsar_lib.py -- no env override whatsoever -- ran extend_orbit fine
+# even nested inside pre_proc.py); the fix here is limited to making
+# sure a Windows-style PATH is what gets fed in, never re-deriving one
+# ourselves.
+
+
+def _bash_env(kwargs):
+    """Pop/build the env= to hand to a bash -c subprocess: caller-supplied
+    env (or a copy of os.environ), with a Windows-style PATH guaranteed
+    (see _WIN_PATH_VAR module comment for why this must NOT be POSIX-
+    converted). Git Bash's own MSYS runtime does the POSIX-vs-Windows
+    translation in both directions from here."""
+    env = dict(kwargs.pop('env', None) or os.environ)
+    win_path = env.get(_WIN_PATH_VAR) or env.get('PATH', '')
+    env[_WIN_PATH_VAR] = win_path
+    env['PATH'] = win_path
+    return env
+
+
+def shell_run(cmd, **kwargs):
+    """subprocess.run() for a POSIX-shell-syntax command string. On POSIX,
+    plain shell=True. On Windows, routes through Git Bash's `bash -c`
+    instead of shell=True's cmd.exe (see _win_bash())."""
+    bash = _win_bash()
+    if bash:
+        return subprocess.run([bash, '-c', cmd], env=_bash_env(kwargs), **kwargs)
+    return subprocess.run(cmd, shell=True, **kwargs)
+
+
+def shell_check_output(cmd, **kwargs):
+    """subprocess.check_output() for a POSIX-shell-syntax command string
+    (pipes, redirections, ...) -- Windows equivalent of shell_run()."""
+    bash = _win_bash()
+    if bash:
+        return subprocess.check_output([bash, '-c', cmd], env=_bash_env(kwargs), **kwargs)
+    return subprocess.check_output(cmd, shell=True, **kwargs)
 
 
 def resolve_sharedir():
     """Return the GMTSAR shared data directory ($GMTSAR/share/gmtsar).
     First tries $GMTSAR env var; falls back to walking up from this file's
-    location looking for share/gmtsar. Raises SystemExit if not found."""
+    location looking for share/gmtsar. Raises SystemExit if not found.
+
+    Returned path always uses forward slashes, even on Windows: callers
+    (filter, fitoffset.py, ...) embed this directly into shell command
+    STRINGS run via shell_run()/run() (e.g. f'conv ... {sharedir}/filters/
+    gauss15x5 ...'), and that string is handed to `bash -c` unquoted --
+    bash's own escaping rules treat backslash+letter as an escape
+    sequence and silently DROP the backslash, corrupting any embedded
+    Windows-style path (D:\\...\\share\\gmtsar becomes D:...sharegmtsar).
+    Forward slashes are valid path separators to both Windows file APIs
+    and bash, so they survive either consumer intact."""
     gmtsar = os.environ.get('GMTSAR')
     if gmtsar:
         candidate = os.path.join(gmtsar, 'share', 'gmtsar')
         if os.path.isdir(candidate):
-            return candidate
+            return candidate.replace('\\', '/')
 
     # Walk up from this file's location (handles direct + symlinked installs).
     cur = os.path.dirname(os.path.realpath(__file__))
     for _ in range(5):
         candidate = os.path.join(cur, 'share', 'gmtsar')
         if os.path.isdir(candidate):
-            return candidate
+            return candidate.replace('\\', '/')
         parent = os.path.dirname(cur)
         if parent == cur:
             break
@@ -126,7 +248,7 @@ def file_shuttle(fn0, fn1, opt):
     else:
         raise ValueError(f"file_shuttle: unknown opt {opt!r}")
     print(cmd)
-    rc = subprocess.run(cmd, shell=True).returncode
+    rc = shell_run(cmd).returncode
     if rc != 0:
         print(f"WARN: file_shuttle exited {rc}: {cmd}", file=sys.stderr)
 
@@ -134,7 +256,7 @@ def delete(fn):
     """Remove a file or directory tree by name. Shells out to preserve glob
     semantics: delete('amp*.grd') must still work. Silent on rm -rf failures
     (matches prior behavior)."""
-    subprocess.run(f"rm -rf {fn}", shell=True)
+    shell_run(f"rm -rf {fn}")
     
 def assign_arg(arg, str):
     # arg is the list that contains arguments from a terminal input.
@@ -175,7 +297,7 @@ def run(cmd):
     print(" ")
     print(f"[{_utc_now()}] {cmd}")
     _t0 = _t.time()
-    rc = subprocess.run(cmd, shell=True).returncode
+    rc = shell_run(cmd).returncode
     _dt = _t.time() - _t0
     print(f"[{_utc_now()}] done in {_dt:.3f}s (rc={rc})")
     try:

--- a/gmtsar/python/utils/intf
+++ b/gmtsar/python/utils/intf
@@ -26,17 +26,21 @@ def Error_Message():
 
 def extractSatBaselineOutputToPrm(refPrm, repPrm):
     # csh command: SAT_baseline $1 $2 | tail -n9 >> $2
-    out = subprocess.run(['SAT_baseline_py', refPrm, repPrm], stdout=subprocess.PIPE)
-    output = out.stdout.decode('utf-8').split('\n')[-10:]
+    # Routed through shell_check_output (bash -c on Windows) rather than
+    # subprocess.run([...]) directly: SAT_baseline_py is an extensionless
+    # shebang script -- Windows' CreateProcess can't exec it (it can only
+    # auto-append ".exe" to a bare name, and there is no SAT_baseline_py.exe).
+    out = shell_check_output(f'SAT_baseline_py {refPrm} {repPrm}')
+    output = out.decode('utf-8').split('\n')[-10:]
     print('INTF: SAT_baseline $1 $2 output is ', out)
     print('INTF: tail -n9 the above output is ', output)
     print('INTF: insert the tail results to file ', repPrm)
     with open(repPrm, 'a') as f:
         f.write('\n'.join(output))
-        
+
     # csh command: SAT_baseline $1 $1 | grep height >> $1
-    out = subprocess.run(['SAT_baseline_py', refPrm, refPrm], stdout=subprocess.PIPE)
-    output = out.stdout.decode('utf-8')
+    out = shell_check_output(f'SAT_baseline_py {refPrm} {refPrm}')
+    output = out.decode('utf-8')
     output = '\n'.join(line for line in output.split('\n') if 'height' in line)
     with open(refPrm, 'a') as f:
         f.write(output)

--- a/gmtsar/python/utils/p2p_stages.py
+++ b/gmtsar/python/utils/p2p_stages.py
@@ -601,7 +601,7 @@ def _iono_intf_block(side, slc_dir, ref, rep, dec, new_incx, new_incy,
             else:
                 # First block: compute landmask region from phase.grd then
                 # produce landmask_ra.grd via the landmask binary.
-                output = subprocess.check_output('gmt grdinfo phase.grd -I-', shell=True)
+                output = shell_check_output('gmt grdinfo phase.grd -I-')
                 rcut = output[2:20].decode('utf-8')
                 os.chdir('../../topo')
                 run(f"landmask {rcut}")
@@ -733,8 +733,8 @@ def _ensure_landmask(sub):
     output of `gmt grdinfo phase.grd -I-` (cols 3-20); legacy code stored
     the command string itself. landmask_ra.grd existence check now uses a
     string literal (legacy code referenced an undefined identifier)."""
-    output = subprocess.check_output('gmt grdinfo phase.grd -I- | cut -c3-20',
-                                     shell=True).decode('utf-8').strip()
+    output = shell_check_output('gmt grdinfo phase.grd -I- | cut -c3-20'
+                                     ).decode('utf-8').strip()
     os.chdir("../../topo")
     if not check_file_report('landmask_ra.grd'):
         run(f"landmask {output}")

--- a/gmtsar/python/utils/proj_ra2ll_lib.py
+++ b/gmtsar/python/utils/proj_ra2ll_lib.py
@@ -54,6 +54,8 @@ import time
 
 import numpy as np
 
+from gmtsar_lib import shell_run
+
 try:
     import xarray as xr
 except ImportError as e:
@@ -235,7 +237,7 @@ def _ensure_raln_ralt(trans_dat: str, region: str, verbose: bool = False) -> Non
                                       out_path="raln.grd")
         else:
             cmd = f"gmt surface {trans_dat} -i0,1,3 -bi5d {region} -I16/32 -T.50 -Graln.grd {Vflag}"
-            subprocess.run(cmd, shell=True, check=False)
+            shell_run(cmd, check=False)
     if not os.path.isfile("ralt.grd"):
         if inproc:
             _run_surface_inproc_5col(trans_dat, region, col_z=4,
@@ -243,7 +245,7 @@ def _ensure_raln_ralt(trans_dat: str, region: str, verbose: bool = False) -> Non
                                       out_path="ralt.grd")
         else:
             cmd = f"gmt surface {trans_dat} -i0,1,4 -bi5d {region} -I16/32 -T.50 -Gralt.grd {Vflag}"
-            subprocess.run(cmd, shell=True, check=False)
+            shell_run(cmd, check=False)
 
 
 def _region_from_corr_extent(z, x_coord, y_coord) -> str:
@@ -411,12 +413,12 @@ def proj_ra2ll_fast(trans_dat: str, in_grd: str, out_grd: str,
 
     # ---- 6. blockmedian -> xyz2grd (UNCHANGED, parity-stable) ----
     t = time.time()
-    subprocess.run(
+    shell_run(
         f"gmt blockmedian llp {R} -bi3f -bo3f -I{fine_inc} -r {Vflag} > llpb",
-        shell=True, check=False)
-    subprocess.run(
+        check=False)
+    shell_run(
         f"gmt xyz2grd llpb {R} -I{fine_inc} -r -fg -G{out_grd} -bi3f",
-        shell=True, check=False)
+        check=False)
     times["blockmedian_xyz2grd"] = time.time() - t
 
     # ---- 7. cleanup ----


### PR DESCRIPTION
## Summary

`gmtsar/python`: framework update v2.8.0 → v2.12.0 since PR #1122. Two real, independently-verified lines of work:

1. **Native Windows install** (`--system conda-windows-full`) — GMTSAR now builds and runs on Windows with no WSL, no MSYS2/Cygwin toolchain, no admin rights. CMake/Ninja build against a conda-provided MinGW-w64 toolchain; a self-contained distributable bundle (`distribute_gmtsar_windows.py`) proven end-to-end (bit-identical RS2 output from the bundle alone, no conda/Git in the environment).
2. **Full conda-toolchain isolation on Linux** (`--system conda-linux-full`) — the existing `--system conda` deliberately keeps the system's own compiler; this adds a genuine opt-in where conda provides the compiler too. Plus: `--conda-env current` (install into an already-active env instead of always creating a separate `gmtsar` one — requested by a real downstream consumer), and a verified `numpy>=2`/`numba>=0.60` bump (previously pinned `numpy<2` with no documented reason).

**A note on scope, disclosed upfront**: this fork's own convention (`gmtsar/python/CLAUDE.md`) has been "dev confined to `gmtsar/python/`, enforced by `git diff upstream/master -- ':!gmtsar/python'` returning empty" since PR #1114/#1122. Native Windows support genuinely requires breaking that boundary — CMake build-system changes (`CMakeLists.txt`, `gmtsar/CMakeLists.txt`, `gmtsar/csh/CMakeLists.txt`) and two new POSIX-compatibility headers (`gmtsar/compat_win32/{getline_shim.h,sys/mman.h}`) that the C sources themselves need on MSVC/MinGW. This is the only PR since #1114 to touch anything outside `gmtsar/python/`; happy to split it out into its own PR if maintainers would prefer reviewing the CMake/Windows-C changes separately from the Python-framework changes.

## Two real upstream C bugs found and fixed

Both fixes are staged at `gmtsar/python/c_fixes/` and applied as a build-time patch by `install.py`'s `_apply_c_fixes()` on every platform — not committed directly to the real files, so this PR includes them as genuine proposed fixes for review rather than silent changes:

- **`gmtsar/fitoffset.c`**: calls `strlcpy()` with no declaration/include anywhere. Implicit-declaration is only a warning on GCC < 14 (invisible on most systems today) but a **hard compile error** on GCC 14+ (which conda-forge's compiler packages already ship, and which Ubuntu 24.10+/Fedora 40+/Arch already ship as their system compiler) — GCC 14 promoted implicit function declarations to an error by default as part of C23 alignment. Will break `--system ubuntu` too on any GCC 14+ host, not just the new conda-isolated mode. Fix: `strlcpy` → `snprintf`, identical behavior for the fixed short literals involved.
- **`gmtsar/conv.c`** *(found and verified in the Windows-focused session, not independently reproduced by me -- I have no Windows machine; the fix itself I confirmed is real and correctly wired in)*: opens the raw SLC file and `.grd=bf` binary-float grid with `fopen(path, "r")` — text mode. No-op on POSIX, but on Windows the CRT translates `\r\n`→`\n` and treats byte `0x1A` as EOF, silently corrupting/truncating the binary stream mid-file. Documented as the root cause of a real symptom found during Windows bring-up: interferogram correlation collapsing to near-zero over ~85% of a real RS2 swath on Windows, while the identical pipeline produced a near-machine-precision match to the C reference on Linux. Fix: `fopen(path, "r")` → `fopen(path, "rb")` at both call sites — harmless on POSIX, fixes the corruption on Windows.

## `install.py`: three real `--system` modes now

- `ubuntu` — unchanged (apt, sudo).
- `conda` — unchanged (system compiler + conda-forge libs), but its platform scope is now actually documented: it was never truly Linux-restricted, it just never said so.
- `conda-linux-full` *(new)* — Linux x86_64 only, conda provides the compiler/build-tool chain too (`gfortran_linux-64`, `gxx_linux-64`, `make`, `autoconf`, `ghostscript`, `tcsh` — no plain `csh` package exists on conda-forge, a `csh -> tcsh` symlink is created automatically). Fails fast with a clear message on any other platform.
- `conda-windows-full` *(new)* — native Windows, no WSL/MSYS2/Cygwin. Still needs Git for Windows (routes POSIX-syntax shell-outs through Git Bash). `distribute_gmtsar_windows.py` packages a self-contained user bundle with full third-party license attribution (`THIRD_PARTY_NOTICES.md`, per-package license texts, an explicit AGPL-3.0/ghostscript callout).

Also: `--conda-env current` (any conda mode) installs directly into whatever env is already active instead of creating a separate `gmtsar`-named one; a pre-flight check for missing system build tools under plain `--system conda` (used to fail with a cryptic `autoconf`/`make` error deep in the build); `locate_conda_env()` now prefers `micromamba` over classic `conda create` when present (classic conda's solver was observed hanging 28+ minutes on this real package set on an older host).

## Test plan

- [x] `tests/test_install.py --system conda --full` (fresh clone, fresh conda env, real 21-case sweep): `install.py` PASS, `gmtsar_sharedir.csh` PASS, `bin_py/tests/` PASS (583 passed/60 skipped/0 failed), `sweep.py --full` 152/161 comparisons SUCCESS — the 9 failures are two pre-existing, already-documented issues unrelated to this PR's changes (an accepted snaphu cycle-slip flake on `ALOS_haiti`, and a stale cached csh test oracle for `S1_Ridgecrest_EQ` missing its `F1`/`F2`/`F3` reference directories entirely, confirmed via direct inspection + the test harness's own "grandfathered" warning) — identical failure set reproduced across two independent full runs.
- [x] `--system conda-linux-full`: multiple real clean-room builds (fresh clone + fresh env each time) — real binaries built, linked, and ran correctly, zero missing shared libraries, `gmt --version`/`p2p_processing` both work from the fully-isolated env.
- [x] `--system conda-windows-full`: two full clean-room runs (fresh clone + fresh conda env) — install rc=0 end-to-end, `sweep.py --fast --cases RS2_SLC_Hawaii --topo-mode-ab` 6/6 SUCCESS matching the same-commit Linux run's numbers. *(Windows-specific claim -- see note below.)*
- [x] `distribute_gmtsar_windows.py` bundle: 3-layer isolated-PATH verify (38/38 exes, bundled python imports, bundled bash) plus a full RS2 `p2p` run from the bundle alone (no conda, no Git for Windows in the environment) — `phasefilt.grd` bit-identical (complex-rms 0.0) to the clean-room sweep's reference. *(Windows-specific claim -- see note below.)*
- [x] `numpy>=2`: genuine clean-room test — fresh env, numpy 2.4.6, full `bin_py/tests/` suite (562 passed/59 skipped/0 failed) including the real C-vs-Python xcorr parity test against real data, bit/float-exact, zero numerical drift.

**Note on provenance**: the `conda-linux-full`, `--conda-env current`, `numpy>=2`, and the two full-sweep verification runs above were run and independently confirmed by me this session. The native-Windows build, the `distribute_gmtsar_windows.py` bundle proof, and the `conv.c` root-cause were developed and verified in a separate session (no Windows machine available to me to independently reproduce) — reported here as-documented in `gmtsar/python/docs/release_notes/release_notes_v2.10.0.md`, `v2.10.2.md`, `v2.10.3.md`, `v2.11.0.md`, and `gmtsar/python/docs/PATHWAY_FORWARD.md`, not re-verified firsthand.

Full details: `gmtsar/python/docs/release_notes/release_notes_v2.9.0.md`, `v2.10.0.md`, `v2.10.2.md`, `v2.10.3.md`, `v2.11.0.md`, `v2.12.0.md` (v2.10.1/v2.11.1 were small patches folded into their commit messages, no separate file). Living ledger of what's ported/wired/tried-and-kept-off: `gmtsar/python/docs/PATHWAY_FORWARD.md`.
