### PR TITLE
preproc: truncate causing the orbit state-vector interval shift

### DIFF
--- a/gmtsar/python/utils/s1a_preproc_lib.py
+++ b/gmtsar/python/utils/s1a_preproc_lib.py
@@ -308,11 +308,38 @@ def pop_led(xml_root: ET.Element):
 
 
 def write_orb(sv, fp) -> int:
-    """Verbatim port of make_slc_s1a.c:write_orb (lines 142-155)."""
+    """Port of make_slc_s1a.c:write_orb (lines 142-155), with the upstream
+    truncation defect fixed -- see the matching change in make_slc_s1a.c,
+    make_s1a_tops.c and make_s1a_tops_6par.c.
+
+    sv['sec'] does not survive its round trip exactly. xml.c str_date2JD()
+    emits the orbit time as a STRING via sprintf("%.12f", doy + MJDfrac) --
+    doy is the day of year, so the fraction of a day keeps ~12 decimals --
+    and pop_led() recovers it as (tmp_d - trunc(tmp_d)) * 86400. A repeating
+    fraction cannot be written exactly in 12 decimals, so each timestamp
+    arrives a few hundredths of a microsecond off, rounded up or down
+    depending on its digits.
+
+    That magnitude is harmless; the SIGN is not. Sentinel-1 state vectors
+    fall on exact integer seconds, which is exactly where a 0.01 s truncation
+    boundary lies, so when one vector lands just above its integer second and
+    the next just below, trunc() floors them in OPPOSITE directions and the
+    difference is short by a whole centisecond (2021-05-19, vectors at
+    48837 s and 48847 s, errors +0.04 and -0.02 us):
+
+        sv[0] 48837.000000039 -> trunc -> 48837.00
+        sv[1] 48846.999999975 -> trunc -> 48846.99      dt = 9.99
+
+    calc_dop_orb divides by dt, so 0.1% inflates SC_vel and stretches the
+    azimuth axis by 0.1% -- observed as a 33-44 line progressive
+    coregistration failure on real data. Rounding at 1e-3 puts the decision
+    boundary 0.5 ms from the value instead of 0, and moves both vectors the
+    same way so their difference stays exact. Matches ext_orb_s1a.c.
+    """
     n = len(sv)
     if n <= 1:
         return -1
-    dt = math.trunc(sv[1]['sec'] * 100.0) / 100.0 - math.trunc(sv[0]['sec'] * 100.0) / 100.0
+    dt = round(sv[1]['sec'] * 1000.0) / 1000.0 - round(sv[0]['sec'] * 1000.0) / 1000.0
     fp.write("%d %d %d %.6lf %lf \n" % (n, sv[0]['yr'], sv[0]['jd'], sv[0]['sec'], dt))
     for s in sv:
         fp.write("%d %d %.6lf %.6lf %.6lf %.6lf %.8lf %.8lf %.8lf \n" % (

--- a/preproc/ENVI_preproc/ENVI_SLC_decode/envi_slc_decode.c
+++ b/preproc/ENVI_preproc/ENVI_SLC_decode/envi_slc_decode.c
@@ -126,7 +126,14 @@ int write_orb(state_vector *sv, FILE *fp, int n) {
 	int i;
 	double dt;
 
-	dt = trunc((sv[1].sec) * 100.0) / 100.0 - trunc((sv[0].sec) * 100.0) / 100.0;
+	/* Round, do not truncate -- see make_s1a_tops.c write_orb(). Orbit times
+	   round-trip through a "%.12f" string in xml.c str_date2JD(), so each
+	   arrives a few hundredths of a microsecond above or below its exact
+	   integer second. Truncating at 0.01 s then floors two adjacent vectors
+	   in OPPOSITE directions and dt comes out 9.99 instead of 10.00, a 0.1%
+	   error that calc_dop_orb propagates into SC_vel. Rounding moves both
+	   the same way, so their difference stays exact. */
+	dt = round((sv[1].sec) * 1000.0) / 1000.0 - round((sv[0].sec) * 1000.0) / 1000.0;
 	if (n <= 1)
 		return (-1);
 	fprintf(fp, "%d %d %d %.6lf %lf \n", n, sv[0].yr, sv[0].jd, sv[0].sec, dt);

--- a/preproc/S1A_preproc/src_swath/make_slc_s1a.c
+++ b/preproc/S1A_preproc/src_swath/make_slc_s1a.c
@@ -143,7 +143,14 @@ int write_orb(state_vector *sv, FILE *fp, int n) {
 	int i;
 	double dt;
 
-	dt = trunc((sv[1].sec) * 100.0) / 100.0 - trunc((sv[0].sec) * 100.0) / 100.0;
+	/* Round, do not truncate -- see make_s1a_tops.c write_orb(). Orbit times
+	   round-trip through a "%.12f" string in xml.c str_date2JD(), so each
+	   arrives a few hundredths of a microsecond above or below its exact
+	   integer second. Truncating at 0.01 s then floors two adjacent vectors
+	   in OPPOSITE directions and dt comes out 9.99 instead of 10.00, a 0.1%
+	   error that calc_dop_orb propagates into SC_vel. Rounding moves both
+	   the same way, so their difference stays exact. */
+	dt = round((sv[1].sec) * 1000.0) / 1000.0 - round((sv[0].sec) * 1000.0) / 1000.0;
 	if (n <= 1)
 		return (-1);
 	fprintf(fp, "%d %d %d %.6lf %lf \n", n, sv[0].yr, sv[0].jd, sv[0].sec, dt);

--- a/preproc/S1A_preproc/src_tops/make_s1a_tops.c
+++ b/preproc/S1A_preproc/src_tops/make_s1a_tops.c
@@ -276,7 +276,32 @@ int write_orb(state_vector *sv, FILE *fp, int n) {
 	int i;
 	double dt;
 
-	dt = trunc((sv[1].sec) * 100.0) / 100.0 - trunc((sv[0].sec) * 100.0) / 100.0;
+	/* Round, do not truncate. sv[].sec does not survive its round trip
+	   exactly: xml.c str_date2JD() emits the orbit time as a STRING via
+	   sprintf("%.12f", doy + MJDfrac) -- doy is the day of year, so the
+	   fraction of a day keeps ~12 decimals -- and pop_led() recovers it as
+	   (tmp_d - trunc(tmp_d)) * 86400. A repeating fraction cannot be written
+	   exactly in 12 decimals, so each timestamp arrives a few hundredths of
+	   a microsecond off, rounded up or down depending on its digits.
+
+	   That magnitude is harmless; the SIGN is not. Sentinel-1 state vectors
+	   fall on exact integer seconds, which is exactly where a 0.01 s
+	   truncation boundary lies, so when one vector lands just above its
+	   integer second and the next just below, trunc floors them in OPPOSITE
+	   directions and the difference is short by a whole centisecond
+	   (2021-05-19, vectors at 48837 s and 48847 s, errors +0.04/-0.02 us):
+
+	       sv[0] 48837.000000039 -> trunc -> 48837.00
+	       sv[1] 48846.999999975 -> trunc -> 48846.99   dt = 9.99
+
+	   calc_dop_orb divides by dt, so 0.1% inflates SC_vel and stretches the
+	   azimuth axis by 0.1% -- a 33-44 line, progressive coregistration
+	   failure that reduces affected interferograms to the noise floor.
+
+	   Rounding is safe because both vectors then move the SAME way, so their
+	   difference is exact for any error below half a millisecond -- ~10,000x
+	   the error actually present. Matches ext_orb_s1a.c's write_orb(). */
+	dt = round((sv[1].sec) * 1000.0) / 1000.0 - round((sv[0].sec) * 1000.0) / 1000.0;
 	if (n <= 1)
 		return (-1);
 	fprintf(fp, "%d %d %d %.6lf %lf \n", n, sv[0].yr, sv[0].jd, sv[0].sec, dt);

--- a/preproc/S1A_preproc/src_tops/make_s1a_tops_6par.c
+++ b/preproc/S1A_preproc/src_tops/make_s1a_tops_6par.c
@@ -193,7 +193,14 @@ int write_orb(state_vector *sv, FILE *fp, int n) {
 	int i;
 	double dt;
 
-	dt = trunc((sv[1].sec) * 100.0) / 100.0 - trunc((sv[0].sec) * 100.0) / 100.0;
+	/* Round, do not truncate -- see make_s1a_tops.c write_orb(). Orbit times
+	   round-trip through a "%.12f" string in xml.c str_date2JD(), so each
+	   arrives a few hundredths of a microsecond above or below its exact
+	   integer second. Truncating at 0.01 s then floors two adjacent vectors
+	   in OPPOSITE directions and dt comes out 9.99 instead of 10.00, a 0.1%
+	   error that calc_dop_orb propagates into SC_vel. Rounding moves both
+	   the same way, so their difference stays exact. */
+	dt = round((sv[1].sec) * 1000.0) / 1000.0 - round((sv[0].sec) * 1000.0) / 1000.0;
 	if (n <= 1)
 		return (-1);
 	fprintf(fp, "%d %d %d %.6lf %lf \n", n, sv[0].yr, sv[0].jd, sv[0].sec, dt);


### PR DESCRIPTION
write_orb() derived the state-vector time step dt by truncating each timestamp to a centisecond and subtracting:

    dt = trunc(sv[1].sec * 100)/100 - trunc(sv[0].sec * 100)/100;

Sentinel-1 state vectors fall on exact integer seconds, which is exactly where a 0.01 s truncation boundary lies, and the timestamps arrive with a few hundredths of a microsecond of error: xml.c str_date2JD() emits the value as a string via sprintf("%.12f", doy + MJDfrac), which cannot represent a repeating fraction of a day exactly, and pop_led() then multiplies the recovered fraction by 86400.

The magnitude of that error is harmless; its SIGN is not. When one vector lands just above its integer second and the next just below, trunc floors them in opposite directions and the difference is short by a full centisecond. Observed on a real acquisition (2021-05-19, vectors at 48837 s and 48847 s, errors +0.04 and -0.02 us):

    sv[0] 48837.000000039 -> trunc -> 48837.00
    sv[1] 48846.999999975 -> trunc -> 48846.99
    dt = 9.990000                      (a 0.02 us error becomes 10 ms)

calc_dop_orb divides by dt, so a 0.1% error inflates SC_vel by 0.1% and stretches the azimuth axis by the same factor. On a 13-scene Sentinel-1 stack this misregistered 2 scenes by 33-44 lines, progressive down-track, and reduced every interferogram spanning them to the noise floor (coherence 0.24 flat, against 0.92-0.98 for the same granules in ISCE2 and HyP3). PRM a_stretch_a recorded it directly: 1.010e-03 on the affected scenes against 1.68e-05 on the rest.

Rounding fixes it because both vectors then move the same way, so their difference is exact for any error below half a millisecond -- a ~10,000x margin over the ~0.04 us actually present. GMTSAR's own ext_orb_s1a.c write_orb() already rounds; this brings the other four copies into line.

Reproduce
```
1. The way I install was using python3 gmtsar/python/install.py --system conda-linux-full
2. 
You may either 1) run repro_dt.c to simulate the error 
[repro_dt.c](https://github.com/user-attachments/files/30805135/repro_dt.c)

or run  repro_from_granule.sh to download real SLC to test the issue
[repro_from_granule.sh](https://github.com/user-attachments/files/30805137/repro_from_granule.sh)

```
